### PR TITLE
Add support for configuring sentry telemetry

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -81,6 +81,9 @@ Enables FlowForge Telemetry
  - `forge.telemetry.posthog.apikey` enables posthog logging if set (not default)
  - `forge.telemetry.posthog.apiurl` sets posthog target host (default `https://app.posthog.com`)
  - `forge.telemetry.posthog.capture_pageview` (default `true`)
+ - `forge.telemetry.sentry.frontend_dsn` enables sentry reporting if set
+ - `forge.telemetry.sentry.backend_dsn` enables sentry reporting if set
+ - `forge.telemetry.sentry.production_mode` late limit reporting (default `true`)
 
  ### Support
 

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -83,7 +83,7 @@ Enables FlowForge Telemetry
  - `forge.telemetry.posthog.capture_pageview` (default `true`)
  - `forge.telemetry.sentry.frontend_dsn` enables sentry reporting if set
  - `forge.telemetry.sentry.backend_dsn` enables sentry reporting if set
- - `forge.telemetry.sentry.production_mode` late limit reporting (default `true`)
+ - `forge.telemetry.sentry.production_mode` rate limit reporting (default `true`)
 
  ### Support
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -150,8 +150,8 @@ data:
         {{ if and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "frontend_dsn") -}}
         sentry:
           dsn: {{ .Values.forge.telemetry.sentry.frontend_dsn}}
-          {{ if hasKey .Values.forge.telemetry.dsn "production_mode" }}
-          production_mode: {{ .Values.forge.telemetry.entry.production_mode }}
+          {{ if hasKey .Values.forge.telemetry.sentry "production_mode" }}
+          production_mode: {{ .Values.forge.telemetry.sentry.production_mode }}
           {{ else }}
           production_mode: true
           {{ end }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -129,7 +129,7 @@ data:
       http: info
     telemetry:
       enabled: {{ .Values.forge.telemetry.enabled }}
-      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) }}
+      {{ if or (.Values.forge.telemetry.plausible) (.Values.forge.telemetry.posthog) (hasKey .Values.forge.telemetry.sentry "frontend_dsn") }}
       frontend:
         {{ if .Values.forge.telemetry.plausible -}}
         plausible:
@@ -147,7 +147,21 @@ data:
           capture_pageview: true
           {{ end }}
         {{ end -}}
+        {{ if and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "frontend_dsn") -}}
+        sentry:
+          dsn: {{ .Values.forge.telemetry.sentry.frontend_dsn}}
+          {{ if hasKey .Values.forge.telemetry.dsn "production_mode" }}
+          production_mode: {{ .Values.forge.telemetry.entry.production_mode }}
+          {{ else }}
+          production_mode: true
+          {{ end }}
+        {{ end -}}
       {{- end }}
+      {{ if and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "backend_dsn") -}}
+      backend:
+        sentry:
+          dsn: {{ .Values.forge.telemetry.sentry.backend_dsn}}
+      {{ end -}}
     {{- if .Values.forge.support.enabled }}
     support:
       enabled: true

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -242,6 +242,20 @@
                             "required": [
                                 "apikey"
                             ]
+                        },
+                        "sentry": {
+                            "type": "object",
+                            "properties": {
+                                "frontend_dsn":{
+                                    "type": "string"
+                                },
+                                "backend_dsn": {
+                                    "type": "string"
+                                },
+                                "production_mode": {
+                                    "type": "boolean"
+                                }
+                            },
                         }
                     }
                 },

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -255,7 +255,7 @@
                                 "production_mode": {
                                     "type": "boolean"
                                 }
-                            },
+                            }
                         }
                     }
                 },

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -43,6 +43,10 @@ forge:
     posthog: 
       capture_pageview: false
       apikey: phc_fdlksajfdfadfsafsaf
+    sentry:
+      production_mode: false
+      frontend_dsn: https://sentry.io/flowforge/flowforge-frontend
+      backend_dsn: https://sentry.io/flowforge/flowforge-backend
   support:
     enabled: true
     hubspot: 12345678

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -45,8 +45,8 @@ forge:
       apikey: phc_fdlksajfdfadfsafsaf
     sentry:
       production_mode: false
-      frontend_dsn: https://sentry.io/flowforge/flowforge-frontend
-      backend_dsn: https://sentry.io/flowforge/flowforge-backend
+      frontend_dsn: 'https://sentry.io/flowforge/flowforge-frontend'
+      backend_dsn: 'https://sentry.io/flowforge/flowforge-backend'
   support:
     enabled: true
     hubspot: 12345678

--- a/test/unit/configmap_spec.js
+++ b/test/unit/configmap_spec.js
@@ -103,4 +103,22 @@ describe('Examine Config Maps', function () {
             })
         })
     })
+
+    describe('customizations.yml', async function () {
+        let yml
+        beforeEach(function () {
+            const d = configMaps.filter(doc => doc.metadata.name === 'flowforge-config')[0]
+            yml = yaml.parse(d.data['customizations.ym'])
+        })
+        it('has sentry telemetry', function () {
+            yml.telemetry.sentry.should.have.property('production_mode')
+            yml.telemetry.sentry.production_mode.should.equal(false)
+
+            yml.telemetry.sentry.should.have.property('frontend_dsn')
+            yml.telemetry.sentry.frontend_dsn.should.equal('https://sentry.io/flowforge/flowforge-frontend')
+
+            yml.telemetry.sentry.should.have.property('backend_dsn')
+            yml.telemetry.sentry.frontend_dsn.should.equal('https://sentry.io/flowforge/flowforge-backend')
+        })
+    })
 })

--- a/test/unit/configmap_spec.js
+++ b/test/unit/configmap_spec.js
@@ -108,17 +108,18 @@ describe('Examine Config Maps', function () {
         let yml
         beforeEach(function () {
             const d = configMaps.filter(doc => doc.metadata.name === 'flowforge-config')[0]
-            yml = yaml.parse(d.data['customizations.ym'])
+            yml = yaml.parse(d.data['flowforge.yml'])
         })
         it('has sentry telemetry', function () {
-            yml.telemetry.sentry.should.have.property('production_mode')
-            yml.telemetry.sentry.production_mode.should.equal(false)
+            console.log(yml.telemetry)
+            yml.telemetry.frontend.sentry.should.have.property('production_mode')
+            yml.telemetry.frontend.sentry.production_mode.should.equal(false)
 
-            yml.telemetry.sentry.should.have.property('frontend_dsn')
-            yml.telemetry.sentry.frontend_dsn.should.equal('https://sentry.io/flowforge/flowforge-frontend')
+            yml.telemetry.frontend.sentry.should.have.property('dsn')
+            yml.telemetry.frontend.sentry.dsn.should.equal('https://sentry.io/flowforge/flowforge-frontend')
 
-            yml.telemetry.sentry.should.have.property('backend_dsn')
-            yml.telemetry.sentry.frontend_dsn.should.equal('https://sentry.io/flowforge/flowforge-backend')
+            yml.telemetry.backend.sentry.should.have.property('dsn')
+            yml.telemetry.backend.sentry.dsn.should.equal('https://sentry.io/flowforge/flowforge-backend')
         })
     })
 })


### PR DESCRIPTION
## Description

For https://github.com/FlowFuse/flowfuse/pull/2862

FlowFuse expects config file in below format:

```
telemetry:
  enabled: true
  frontend:
    sentry:
      dsn: 'https://URL-HERE.com'
      production_mode: false
  backend:
    sentry:
      dsn:  'https://URL-HERE.com'

```

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/pull/2862

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

