### PR TITLE
config: Add Prometheus config

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -84,6 +84,7 @@ Enables FlowForge Telemetry
  - `forge.telemetry.sentry.frontend_dsn` enables sentry reporting if set
  - `forge.telemetry.sentry.backend_dsn` enables sentry reporting if set
  - `forge.telemetry.sentry.production_mode` rate limit reporting (default `true`)
+ - `forge.telemetry.backend.prometheus.enabled` enables the `/metrics` endpoint on the forge app for scraping by Prometheus
 
  ### Support
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -157,11 +157,13 @@ data:
           {{ end }}
         {{ end -}}
       {{- end }}
-      {{ if and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "backend_dsn") -}}
       backend:
+        {{ if and (hasKey .Values.forge.telemetry "sentry") (hasKey .Values.forge.telemetry.sentry "backend_dsn") -}}
         sentry:
           dsn: {{ .Values.forge.telemetry.sentry.backend_dsn}}
-      {{ end -}}
+        {{- end }}
+        prometheus:
+          enabled: {{ .Values.forge.telemetry.backend.prometheus.enabled }}
     {{- if .Values.forge.support.enabled }}
     support:
       enabled: true

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -256,6 +256,19 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "backend": {
+                            "type": "object",
+                            "properties": {
+                                "prometheus": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -16,6 +16,9 @@ forge:
     role: management
   telemetry:
     enabled: true
+    backend:
+      prometheus:
+        enabled: false
   broker:
     enabled: false
   fileStore:

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -47,6 +47,9 @@ forge:
       production_mode: false
       frontend_dsn: 'https://sentry.io/flowforge/flowforge-frontend'
       backend_dsn: 'https://sentry.io/flowforge/flowforge-backend'
+    backend:
+      prometheus:
+        enabled: true
   support:
     enabled: true
     hubspot: 12345678

--- a/test/unit/configmap_spec.js
+++ b/test/unit/configmap_spec.js
@@ -116,8 +116,8 @@ describe('Examine Config Maps', function () {
             const d = configMaps.filter(doc => doc.metadata.name === 'flowforge-config')[0]
             yml = yaml.parse(d.data['flowforge.yml'])
         })
+
         it('has sentry telemetry', function () {
-            console.log(yml.telemetry)
             yml.telemetry.frontend.sentry.should.have.property('production_mode')
             yml.telemetry.frontend.sentry.production_mode.should.equal(false)
 
@@ -126,6 +126,12 @@ describe('Examine Config Maps', function () {
 
             yml.telemetry.backend.sentry.should.have.property('dsn')
             yml.telemetry.backend.sentry.dsn.should.equal('https://sentry.io/flowforge/flowforge-backend')
+        })
+
+        describe('using Prometheus', function () {
+            it('has prometheus enabled', function() {
+                yml.telemetry.backend.prometheus.enabled.should.equal(true)
+            })   
         })
     })
 })


### PR DESCRIPTION
The application now features a [/metrics endpoint][1] for Prometheus to scrape. Since merging, the configuration file structure has been updated since through [another PR][2].

This change requires both changes to be in the application and afterwards allows enabling the endpoint and an engineer to configure scraping of the data.

[1]: https://github.com/FlowFuse/flowfuse/pull/2889
[2]: https://github.com/FlowFuse/flowfuse/pull/2893
