### PR TITLE
Pin reusable workflows to tag instead of SHA

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.1.0
     with:
       image_name: 'file-server'
       package_dependencies: |
@@ -37,7 +37,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.1.0
     with:
       image_name: 'file-server'
     secrets:
@@ -46,7 +46,7 @@ jobs:
   deploy-stage:
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0
     with:
       environment: stage
       service_name: 'file-server'
@@ -63,7 +63,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0
     with:
       environment: production
       service_name: 'file-server'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.1.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -38,7 +38,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.1.0
     with:
       image_name: 'forge-k8s'
     secrets:
@@ -47,7 +47,7 @@ jobs:
   deploy-stage:
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -64,7 +64,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@7808b849474ae9bc8dfc7f6db19e66d241018c94
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0
     with:
       environment: production
       service_name: 'forge-k8s'


### PR DESCRIPTION
## Description

Pin reusable workflows to tag instead of SHA

## Related Issue(s)

[#276](https://github.com/FlowFuse/CloudProject/issues/276)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

