### PR TITLE
Push Node-RED images to production ECR

### DIFF
--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -61,6 +61,24 @@ jobs:
       aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
+  upload-302-prod:
+    name: Upload image to production ECR
+    if: github.ref_name == 'main'
+    needs: build-302-multi-architecture
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
+    with:
+      environment: prodution
+      service_name: 'node-red'
+      deployment_name: 'node-red'
+      container_name: 'node-red'
+      deploy: false
+      image: ${{ needs.build-302-multi-architecture.outputs.image }}
+      image_tag_prefix: '3.0.2-'
+    secrets:
+      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
+      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
   build-223:
     name: Build 2.2.3 container images
@@ -102,6 +120,24 @@ jobs:
       aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
+  upload-223-prod:
+    name: Upload image to staging ECR
+    if: github.ref_name == 'main'
+    needs: build-223-multi-architecture
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
+    with:
+      environment: prodution
+      service_name: 'node-red'
+      deployment_name: 'node-red'
+      container_name: 'node-red'
+      deploy: false
+      image: ${{ needs.build-223-multi-architecture.outputs.image }}
+      image_tag_prefix: '2.2.3-'
+    secrets:
+      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
+      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
   build-310:
     name: Build 3.1.0 container images
@@ -141,5 +177,23 @@ jobs:
     secrets:
       aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
       aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
+  upload-310-prod:
+    name: Upload image to staging ECR
+    if: github.ref_name == 'main'
+    needs: build-310-multi-architecture
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
+    with:
+      environment: production
+      service_name: 'node-red'
+      deployment_name: 'node-red'
+      container_name: 'node-red'
+      deploy: false
+      image: ${{ needs.build-310-multi-architecture.outputs.image }}
+      image_tag_prefix: '3.1.0-'
+    secrets:
+      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
+      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}


### PR DESCRIPTION
## Description

Push Node-RED images to the production ECR.

## Related Issue(s)

#207 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

