### PR TITLE
FIX: typo in environment name in Node-Red container pipeline

### DIFF
--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -67,7 +67,7 @@ jobs:
     needs: build-302-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
     with:
-      environment: prodution
+      environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
@@ -126,7 +126,7 @@ jobs:
     needs: build-223-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
     with:
-      environment: prodution
+      environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'


### PR DESCRIPTION
## Description

Fix the typo in the environment name in Node-Red container build pipeline.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

