### PR TITLE
Add support for setting Content Security Policy

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -133,6 +133,13 @@ Enables FlowForge Telemetry
  - `forge.rate_limits.max` Max requests per timeWindow (default 1000)
  - `forge.rate_limits.maxAnonymous` Max anonymous requests per timeWindow (default `forge.rate_limits.max`)
 
+ ### Content Security Policy
+
+ - `forge.contentSecurityPolicy.enabled` Enabled HTTP header from Forge app (default `false`)
+ - `forge.contentSecurityPolicy.reportOnly` Disables enforcing and only reports in browser console (default `false`)
+ - `forge.contentSecurityPolicy.reportUri` if `reportOnly` enabled causes browser to POST report to URI (default not set)
+ - `forge.contentSecurityPolicy.directives` a JSON object that overrides the platform defaults. Uses format defined by HelmetJS [here](https://helmetjs.github.io/#content-security-policy)
+
 Everything under `forge.rate_limits` is used as input to Fastify Rate Limit plugin, further options can be found [here](https://github.com/fastify/fastify-rate-limit#options) and can be included.
 
  ### Ingress

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -183,3 +183,18 @@ data:
     rate_limits:
 {{ toYaml .Values.forge.rate_limits | indent 6 }}
     {{- end }}
+    {{- if and (hasKey .Values.forge "contentSecurityPolicy") (hasKey .Values.forge.contentSecurityPolicy "enabled") }}
+    {{- if .Values.forge.contentSecurityPolicy.enabled }}
+    content_security_policy:
+      enabled: {{.Values.forge.contentSecurityPolicy.enabled}}
+      {{- if (hasKey .Values.forge.contentSecurityPolicy "directives")}}
+      directives: {{.Values.forge.contentSecurityPolicy.directives | toJson}}
+      {{- end }}
+      {{- if and (hasKey .Values.forge.contentSecurityPolicy "reportOnly") (.Values.forge.contentSecurityPolicy.reportOnly)}}
+      report_only: {{.Values.forge.contentSecurityPolicy.reportOnly}}
+      {{- if (hasKey .Values.forge.contentSecurityPolicy "reportUri")}}
+      report_uri: {{.Values.forge.contentSecurityPolicy.reportUri}}
+      {{- end }}
+      {{- end}}
+    {{- end }}
+    {{- end }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -350,6 +350,23 @@
                             "type": "integer"
                         }
                     }
+                },
+                "contentSecurityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "directives": {
+                            "type": "object"
+                        },
+                        "reportOnly": {
+                            "type": "boolean"
+                        },
+                        "reportUri": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
             "required": [

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -51,6 +51,10 @@ forge:
   image: ""
   registry: ""
 
+  contentSecurityPolicy:
+    enabled: false
+    reportOnly: false
+
 postgresql:
   postgresqlPostgresPassword: Moomiet0
   postgresqlUsername: forge


### PR DESCRIPTION
part of https://github.com/flowfuse/security/issues/31
## Description

<!-- Describe your changes in detail -->
Add support for setting the options to configure the Content Security Policy

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/flowfuse/security/issues/31

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

