### PR TITLE
Node 18 containers

### DIFF
--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN
@@ -16,13 +16,13 @@ WORKDIR /usr/src/flowforge-file-server/app
 RUN npm install --production --no-audit --no-fund
 ENV FLOWFORGE_HOME=/usr/src/flowforge-file-server
 
-LABEL org.label-schema.name="Flowforge File Storage" \
-    org.label-schema.url="https://flowforge.com" \
+LABEL org.label-schema.name="FlowFuse File Storage" \
+    org.label-schema.url="https://flowfuse.com" \
     org.label-schema.vcs-type="Git" \
-    org.label-schema.vcs-url="https://github.com/flowforge/flowforge-file-storage" \
-    org.label-schema.docker.dockerfile="flowforge-container/Dockerfile" \
+    org.label-schema.vcs-url="https://github.com/flowfuse/helm" \
+    org.label-schema.docker.dockerfile="fileserver/Dockerfile" \
     org.schema-label.description="Collaborative, low code integration and automation environment" \
-    authors="Flowforge Inc."
+    authors="FlowFuse Inc."
 
 EXPOSE 3001
 

--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -7,7 +7,7 @@ RUN if [[ ! -z "$REGISTRY_TOKEN" ]]; then echo "//$REGISTRY/:_authToken=$REGISTR
 RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "https://$REGISTRY"; fi
 
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
-RUN npm config set python `which python3` --global
+# RUN npm config set python `which python3` --global
 
 WORKDIR /usr/src/flowforge-file-server
 RUN mkdir app bin etc var

--- a/file-server/README.md
+++ b/file-server/README.md
@@ -1,6 +1,6 @@
-# FlowForge File Server
+# FlowFuse File Server
 
-This container provides the backing for the FlowForge replacement Node-RED File nodes.
+This container provides the backing for the FlowFuse replacement Node-RED File nodes.
 
 It supports storing files either using a mounted volume or a S3 bucket
 

--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -17,13 +17,13 @@ WORKDIR /usr/src/forge/app
 RUN npm install --production --no-audit --no-fund
 ENV FLOWFORGE_HOME=/usr/src/forge
 
-LABEL org.label-schema.name="Flowforge Kubernetes" \
-    org.label-schema.url="https://flowforge.com" \
+LABEL org.label-schema.name="FlowFuse Kubernetes" \
+    org.label-schema.url="https://flowfuse.com" \
     org.label-schema.vcs-type="Git" \
-    org.label-schema.vcs-url="https://github.com/flowforge/helm" \
+    org.label-schema.vcs-url="https://github.com/flowfuse/helm" \
     org.label-schema.docker.dockerfile="flowforge-container/Dockerfile" \
     org.schema-label.description="Collaborative, low code integration and automation environment" \
-    authors="Flowforge Inc."
+    authors="FlowFuse Inc."
 
 EXPOSE 3000
 

--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN

--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -7,7 +7,7 @@ RUN if [[ ! -z "$REGISTRY_TOKEN" ]]; then echo "//$REGISTRY/:_authToken=$REGISTR
 RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "https://$REGISTRY"; fi
 
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
-RUN npm config set python `which python3` --global
+# RUN npm config set python `which python3` --global
 
 WORKDIR /usr/src/forge
 RUN mkdir app bin etc var

--- a/flowforge-container/README.md
+++ b/flowforge-container/README.md
@@ -1,12 +1,12 @@
-# FlowForge Kubernetes
+# FlowFuse Kubernetes
 
-The [FlowForge](https://flowforge.com) app with the Kubernetes Container driver bundled.
+The [FlowFuse](https://flowfuse.com) app with the Kubernetes Container driver bundled.
 
-Expected to be used to the FlowForge [Helm chart](https://github.com/flowforge/helm/)
+Expected to be used to the FlowFuse [Helm chart](https://github.com/flowfuse/helm/)
 
 ## Configuration
 
-This container expects a `/usr/src/forge/etc/flowforge.yml` file to be mounted containing the configuration information for this instance of FlowForge.
+This container expects a `/usr/src/forge/etc/flowforge.yml` file to be mounted containing the configuration information for this instance of FlowFuse.
 
 ## Exposed Ports
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Update FlowFuse containers to NodeJS 18 as NodeJS 16 is not receiving security updates any more.

Also updated the labels and the cosponsoring README.md files to FlowFuse

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

