### PR TITLE
FIX: Allow to handle multiline ingress annotations

### DIFF
--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -133,9 +133,7 @@ metadata:
     app: flowforge-broker
   {{- if .Values.ingress.annotations }}
   annotations:
-    {{- range $keys, $values := .Values.ingress.annotations }}
-    {{ $keys }}: {{ $values | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker"}}
-    {{- end }}
+{{ toYaml .Values.ingress.annotations | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
   {{- end }}
 spec:
   {{- if $.Values.ingress.className }}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -17,9 +17,7 @@ metadata:
   name: flowforge-ingress
   {{- if .Values.ingress.annotations }}
   annotations:
-    {{- range $keys, $values := .Values.ingress.annotations }}
-    {{ $keys }}: {{ $values |  replace "{{ instanceHost }}" $forgeHostname | replace "{{ serviceName }}" "forge"}}
-    {{- end }}
+{{ toYaml .Values.ingress.annotations |  replace "{{ instanceHost }}" $forgeHostname | replace "{{ serviceName }}" "forge" | indent 4 }}
   {{- end }}
 spec:
   {{- if and $.Values.ingress.className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}


### PR DESCRIPTION
## Description

Allow to handle multiline ingress annotations.

## Related Issue(s)

#214 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

