### PR TITLE
Validate value of `domain` property

### DIFF
--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -8,7 +8,8 @@
                     "type": "string"
                 },
                 "domain": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,6}$"
                 },
                 "baseURL": {
                     "type": "string"

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -9,7 +9,7 @@
                 },
                 "domain": {
                     "type": "string",
-                    "pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,6}$"
+                    "pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,25}$"
                 },
                 "baseURL": {
                     "type": "string"


### PR DESCRIPTION
## Description

This PR assures, that `forge.domain` value contains a valid domain name.
In result, installation without proper domain set will fail with:
```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
flowforge:
- forge.domain: Does not match pattern '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,6}$'
```

## Related Issue(s)

#226 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

