### PR TITLE
Remove `postgresql.global.storageClass` from default chart values

### DIFF
--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -60,8 +60,6 @@ postgresql:
   postgresqlUsername: forge
   postgresqlPassword: Zai1Wied
   postgresqlDatabase: flowforge
-  global:
-    storageClass: default
 
 ingress:
   annotations: {}


### PR DESCRIPTION
## Description

Remove `postgresql.global.storageClass` from default chart values. Value still can be adjusted using an external values file.

## Related Issue(s)

#225 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

