### PR TITLE
Use environment-scoped AWS credentials in pipelines

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -71,7 +71,7 @@ jobs:
       container_name: 'file-storage'
       image: ${{ needs.build-multi-architecture.outputs.image }}
     secrets:
-      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}

--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -54,8 +54,8 @@ jobs:
       container_name: 'file-storage'
       image: ${{ needs.build-multi-architecture.outputs.image }}
     secrets:
-      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -55,8 +55,8 @@ jobs:
       container_name: forge
       image: ${{ needs.build-multi-architecture.outputs.image }}
     secrets:
-      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
   

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -72,7 +72,7 @@ jobs:
       container_name: forge
       image: ${{ needs.build-multi-architecture.outputs.image }}
     secrets:
-      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -75,8 +75,8 @@ jobs:
       image: ${{ needs.build-302-multi-architecture.outputs.image }}
       image_tag_prefix: '3.0.2-'
     secrets:
-      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
@@ -134,8 +134,8 @@ jobs:
       image: ${{ needs.build-223-multi-architecture.outputs.image }}
       image_tag_prefix: '2.2.3-'
     secrets:
-      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
@@ -193,7 +193,7 @@ jobs:
       image: ${{ needs.build-310-multi-architecture.outputs.image }}
       image_tag_prefix: '3.1.0-'
     secrets:
-      aws_access_key_id: ${{ secrets.PRODUCTION_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.PRODUCTION_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -57,8 +57,8 @@ jobs:
       image: ${{ needs.build-302-multi-architecture.outputs.image }}
       image_tag_prefix: '3.0.2-'
     secrets:
-      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
   upload-302-prod:
@@ -116,8 +116,8 @@ jobs:
       image: ${{ needs.build-223-multi-architecture.outputs.image }}
       image_tag_prefix: '2.2.3-'
     secrets:
-      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
   upload-223-prod:
@@ -175,8 +175,8 @@ jobs:
       image: ${{ needs.build-310-multi-architecture.outputs.image }}
       image_tag_prefix: '3.1.0-'
     secrets:
-      aws_access_key_id: ${{ secrets.STAGING_AWS_ID }}
-      aws_secret_access_key: ${{ secrets.STAGING_AWS_KEY }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
   upload-310-prod:


### PR DESCRIPTION
## Description

Use environment-scoped AWS credentials in pipelines

## Related Issue(s)

#208 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

