### PR TITLE
Update file server to new npm scope

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       image_name: 'file-server'
       package_dependencies: |
-        @flowforge/file-server
+        @flowfuse/file-server
       build_context: 'file-server'
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
     secrets:

--- a/file-server/package.json
+++ b/file-server/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "@flowforge/file-server-container",
+    "name": "@flowfuse/file-server-container",
     "version": "1.14.0",
     "private": true,
     "dependencies": {
-        "@flowforge/file-server": "^1.14.0"
+        "@flowfuse/file-server": "^1.14.0"
     },
     "license": "Apache-2.0"
 }


### PR DESCRIPTION
Update the File Server contain to use the `@flowfuse` npm package.

**Note**: this should not be merged until https://github.com/FlowFuse/file-server/pull/86 is merged and I confirm we've done an initial publish of the package to the new scope.