### PR TITLE
Add possibility to customise clusterrole name

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -42,6 +42,7 @@ If using an external PostgreSQL Database you will need to create the database an
  - `forge.license` FlowForge EE license string (optional, default not set)
  - `forge.branding` Object holding branding inserts (default not set)
  - `forge.projectDeploymentTolerations` tolerations settings for Project instances. Default is `[]`.
+ - `forge.clusterRole.name` custom name for the ClusterRole (default `create-pod`)
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
   

--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -29,7 +29,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: create-pod
+  name: {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "pods/exec", "pods/status"]
@@ -53,7 +53,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: create-pod
+  name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
   namespace: {{ .Values.forge.projectNamespace }}
 subjects:
 - kind: ServiceAccount
@@ -61,5 +61,5 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: create-pod
+  name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -374,6 +374,15 @@
                             "type": "string"
                         }
                     }
+                },
+                "clusterRole": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of cluster role"
+                        }
+                    }
                 }
             },
             "required": [


### PR DESCRIPTION
## Description

Increase configuration flexibility by adding a possibility to customise clusterrole name.
The reason for adding this feature is an attempt to install multiple FlowFuse apps on the same Kubernetes cluster. Since ClusterRole is a cluster-level object, the name must be unique.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

