### PR TITLE
FIX: workflows tag version reference

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@0.2.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.2.1
     with:
       image_name: 'file-server'
       package_dependencies: |

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@0.2.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.2.1
     with:
       image_name: 'forge-k8s'
       package_dependencies: |

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-302:
     name: Build 3.0.2 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@0.2.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.2.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
@@ -83,7 +83,7 @@ jobs:
 
   build-223:
     name: Build 2.2.3 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@0.2.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.2.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-2.2.x
@@ -143,7 +143,7 @@ jobs:
 
   build-310:
     name: Build 3.1.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@0.2.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.2.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-3.1


### PR DESCRIPTION
## Description

This pull request fixes the tag version reference in the workflows file, updating it from `0.2.1` to `v0.2.1`.

## Related Issue(s)

[#208](https://github.com/FlowFuse/CloudProject/issues/208)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

