### PR TITLE
Add support for using cert manager to issue TLS certs

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -148,6 +148,7 @@ Everything under `forge.rate_limits` is used as input to Fastify Rate Limit plug
  ### Ingress
  - `ingress.annotations` ingress annotations (default is `{}`). This value is also applied to Editor instances created by FlowForge.
  - `ingress.className` ingress class name (default is `"""`). This value is also applied to Editor instances created by FlowForge. 
+ - `ingress.certManagerIssuer` the name of the CertManager Issuer to use to create HTTPS certificates. (default is not set)
 
  `ingress.annotations` values can contain the following tokens that will be replaced as follows:
 

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -134,8 +134,11 @@ metadata:
   name: flowforge-broker
   labels:
     app: flowforge-broker
-  {{- if .Values.ingress.annotations }}
   annotations:
+  {{- if .Values.ingress.certManagerIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
   {{- end }}
 spec:
@@ -153,6 +156,12 @@ spec:
                 name: flowforge-broker
                 port:
                   number: 1884
+  {{- if .Values.ingress.certManagerIssuer }}
+  tls:
+  - hosts:
+    - mqtt.{{ .Values.forge.domain }}
+    secretName: broker-tls
+  {{- end }}
 # ---
 # apiVersion: v1
 # kind: Service

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -160,7 +160,7 @@ spec:
   tls:
   - hosts:
     - mqtt.{{ .Values.forge.domain }}
-    secretName: broker-tls
+    secretName: mqtt.{{ .Values.forge.domain }}
   {{- end }}
 # ---
 # apiVersion: v1

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -53,6 +53,9 @@ data:
         {{- if .Values.forge.privateCA }}
         privateCA: {{ .Values.forge.privateCA.configMapName }}
         {{- end }}
+        {{- if .Values.ingress.certManagerIssuer }}
+        certManagerIssuer: {{ .Values.ingress.certManagerIssuer }}
+        {{- end }}
     {{- if .Values.forge.email }}
     email:
       enabled: true

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -41,5 +41,5 @@ spec:
   tls:
   - hosts:
     - {{ $forgeHostname }}
-    secretName: flowforge-tls
+    secretName: {{ $forgeHostname }}
   {{- end }}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -15,8 +15,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flowforge-ingress
-  {{- if .Values.ingress.annotations }}
   annotations:
+  {{- if .Values.ingress.certManagerIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations |  replace "{{ instanceHost }}" $forgeHostname | replace "{{ serviceName }}" "forge" | indent 4 }}
   {{- end }}
 spec:
@@ -24,7 +27,7 @@ spec:
   ingressClassName: {{ $.Values.ingress.className }}
   {{- end }}
   rules:
-  - host: {{ $forgeHostname}}
+  - host: {{ $forgeHostname }}
     http:
       paths:
       - pathType: Prefix
@@ -34,3 +37,9 @@ spec:
             name: forge
             port:
               number: 80
+  {{- if .Values.ingress.certManagerIssuer }}
+  tls:
+  - hosts:
+    - {{ $forgeHostname }}
+    secretName: flowforge-tls
+  {{- end }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -412,6 +412,9 @@
                 },
                 "className": {
                     "type": "string"
+                },
+                "certManagerIssuer": {
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This allows K8s to use cert-manager.io to issue TLS certs for both the core Forge apps and the Instances.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

