### PR TITLE
feat: Deploy to stage from main branch only

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -45,6 +45,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-stage:
+    if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -46,6 +46,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   
   deploy-stage:
+    if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.1.0

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -47,6 +47,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-302-stage:
     name: Upload image to staging ECR
+    if: github.ref_name == 'main'
     needs: build-302-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
     with:
@@ -107,6 +108,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-223-stage:
     name: Upload image to staging ECR
+    if: github.ref_name == 'main'
     needs: build-223-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
     with:
@@ -167,6 +169,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-310-stage:
     name: Upload image to staging ECR
+    if: github.ref_name == 'main'
     needs: build-310-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.2.0
     with:


### PR DESCRIPTION
## Description

PR changes the condition when deployment to the stage environment is executed. After the change deployment will be possible from `main` branch only.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

