### PR TITLE
chore: Update GitHub Actions workflows to use v0.4.1

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
     with:
       image_name: 'file-server'
       package_dependencies: |
@@ -38,7 +38,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
     with:
       image_name: 'file-server'
     secrets:
@@ -48,7 +48,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: stage
       service_name: 'file-server'
@@ -65,7 +65,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: production
       service_name: 'file-server'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -39,7 +39,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
     with:
       image_name: 'forge-k8s'
     secrets:
@@ -49,7 +49,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -66,7 +66,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: production
       service_name: 'forge-k8s'

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-302:
     name: Build 3.0.2 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
@@ -39,7 +39,7 @@ jobs:
   build-302-multi-architecture:
     name: Build multi-architecture container image
     needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.0.2-'
@@ -49,7 +49,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: stage
       service_name: 'node-red'
@@ -67,7 +67,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: production
       service_name: 'node-red'
@@ -84,7 +84,7 @@ jobs:
 
   build-223:
     name: Build 2.2.3 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-2.2.x
@@ -100,7 +100,7 @@ jobs:
   build-223-multi-architecture:
     name: Build multi-architecture container image
     needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
     with:
       image_name: 'node-red'
       image_tag_prefix: '2.2.3-'
@@ -110,7 +110,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: stage
       service_name: 'node-red'
@@ -128,7 +128,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: production
       service_name: 'node-red'
@@ -145,7 +145,7 @@ jobs:
 
   build-310:
     name: Build 3.1.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-3.1
@@ -161,7 +161,7 @@ jobs:
   build-310-multi-architecture:
     name: Build multi-architecture container image
     needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.1.x-'
@@ -171,7 +171,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: stage
       service_name: 'node-red'
@@ -189,7 +189,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
     with:
       environment: production
       service_name: 'node-red'


### PR DESCRIPTION
## Description

Bump workflows v4.0.1 due to minor bug in input values.

Depends on:

- [x] https://github.com/FlowFuse/github-actions-workflows/pull/33 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

