### PR TITLE
feat: Keep database credentials in kubernetes secrets

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -11,12 +11,12 @@ using a local database
 
 If using an external PostgreSQL Database you will need to create the database and user to pass to the helm chart using the following values:
 
-- `forge.dbName`
-- `forge.dbUsername`
-- `forge.dbPassword`
-- `forge.postgres.host`
-- `forge.postgres.port`
-- `forge.postgres.ssl`
+- `postgresql.host`
+- `postgresql.auth.username`
+- `postgresql.auth.password`
+- `postgresql.auth.database`
+
+For other values please refer to the documentation below.
 
 ## Configuration Values
 
@@ -27,13 +27,7 @@ If using an external PostgreSQL Database you will need to create the database an
  - `forge.entryPoint` if the admin app is hosted on a different domain
  - `forge.https` is the Forge App accessed via HTTPS (default `true`)
  - `forge.registry` the container registry to find Project templates (default Docker Hub)
- - `forge.dbUsername` (default `forge`)
- - `forge.dbPassword` (default `Zai1Wied`)
- - `forge.dbName` (default `flowforge`)
  - `forge.localPostrgresql` Deploy a PostgreSQL v14 Database into Kubernetes cluster (default `true`)
- - `forge.postgres.host` the hostname of an external PostgreSQL database (default not set)
- - `forge.postgres.port` the port of an external PostgreSQL database (default `5432`)
- - `forge.postgres.ssl` sets the connection to the database to use SSL/TLS (default `false`)
  - `forge.cloudProvider` currently only accepts `aws` but will include more as needed (default not set)
  - `forge.projectSelector` a collection of labels and values to filter nodes that Project Pods will run on (default `role: projects`)
  - `forge.managementSelector` a collection of labels and values to filter nodes the Forge App will run on (default `role: management`)
@@ -180,3 +174,12 @@ editors:
     create: true
     name: editors
 ```
+
+ ### Postgresql
+ - `postgresql.host` - the hostname of an external PostgreSQL database (default not set)
+ - `postgresql.port` - the port of an external PostgreSQL database (default `5432`)
+ - `postgresql.ssl` - sets the connection to the database to use SSL/TLS (default `false`)
+ - `postgresql.auth.username` - the username to use to connect to the database (default `forge`)
+ - `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
+ - `postgresql.auth.database` - the database to use (default `flowforge`)
+ - `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)

--- a/helm/flowforge/ci/ci-values.yaml
+++ b/helm/flowforge/ci/ci-values.yaml
@@ -1,7 +1,4 @@
 forge:
-  dbUsername: forge
-  dbPassword: Zai1Wied
-  dbName: flowforge
   localPostgresql: true
   https: true
   projectNamespace: flowforge
@@ -32,10 +29,6 @@ forge:
       quota: 1048576
       options:
         type: postgres
-        host: flowforge-postgresql
-        username: forge
-        password: Zai1Wied
-        database: ff-context
   support:
     enabled: false
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -19,14 +19,14 @@ data:
     db:
       type: postgres
       host: {{ .Release.Name }}-postgresql
-      {{- if and (not .Values.forge.localPostgresql) (.Values.forge.postgres) }}
-      port: {{ .Values.forge.postgres.port | default 5432 }}
+      {{- if and (not .Values.forge.localPostgresql) (.Values.postgresql) }}
+      port: {{ .Values.postgresql.port | default 5432 }}
       {{- end }}
-      user: {{ .Values.forge.dbUsername }}
-      password: {{ .Values.forge.dbPassword }}
-      db: {{ .Values.forge.dbName }}
-      {{- if and (hasKey .Values.forge "postgres") (hasKey .Values.forge.postgres "ssl") }}
-      ssl: {{ .Values.forge.postgres.ssl }}
+      user: {{ .Values.postgresql.auth.username }}
+      password: <%= ENV['PGPASSWORD'] %>
+      db: {{ .Values.postgresql.auth.database }}
+      {{- if .Values.postgresql.ssl }}
+      ssl: {{ .Values.postgresql.ssl }}
       {{- end }}
     driver:
       type: kubernetes

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -23,6 +23,21 @@ spec:
       serviceAccountName: flowforge
       securityContext:
         {{- toYaml .Values.forge.podSecurityContext | nindent 8 }}
+      initContainers:
+      - name: config
+        image: "ruby:2.7-slim"
+        command: ['sh', '-c', 'erb /tmpl/flowforge.yml > /config/flowforge.yml']
+        volumeMounts:
+          - name: configtemplate
+            mountPath: /tmpl
+          - name: configdir
+            mountPath: /config
+        env:
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: flowfuse-secrets
+                key: password
       containers:
       - name: forge
         {{- if .Values.forge.image }}
@@ -63,7 +78,7 @@ spec:
         - name: NODE_ENV
           value: production
         volumeMounts:
-        - name: config
+        - name: configdir
           mountPath: /usr/src/forge/etc
         {{- if .Values.forge.privateCA }}
         - name: cacert
@@ -85,7 +100,9 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
-      - name: config
+      - name: configdir
+        emptyDir: {}
+      - name: configtemplate
         configMap:
           name: flowforge-config
       {{- if .Values.forge.privateCA }}

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -23,8 +23,20 @@ data:
       {{- if .Values.forge.fileStore.context.quota }}
       quota: {{ .Values.forge.fileStore.context.quota }}
       {{- end }}
+      {{- if .Values.forge.fileStore.context.options }}}
       options:
-{{ toYaml .Values.forge.fileStore.context.options | indent 8 -}}
+        type: {{ .Values.forge.fileStore.context.options.type }}
+        {{- if eq .Values.forge.fileStore.context.options.type "postgres" }}
+        host: {{ .Values.postgresql.host | default "{{ .Release.Name }}-postgresql" }}
+        port: {{ .Values.postgresql.port | default 5432 }}
+        username: {{ .Values.postgresql.auth.username }}
+        database: ff-context
+        password: <%= ENV['PGPASSWORD'] %>
+        {{- end }}
+        {{- if eq .Values.forge.fileStore.context.options.type "sqlite" }}
+        storage: {{ .Values.forge.fileStore.context.options.storage }}
+        {{- end }}
+      {{- end }}
     {{- end }}
     logging:
       level: info
@@ -62,6 +74,21 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.forge.fileStore.podSecurityContext | nindent 8 }}
+      initContainers:
+      - name: config
+        image: "ruby:2.7-slim"
+        command: ['sh', '-c', 'erb /tmpl/flowforge-storage.yml > /config/flowforge-storage.yml' ]
+        volumeMounts:
+          - name: configtemplate
+            mountPath: /tmpl
+          - name: configdir
+            mountPath: /config
+        env:
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: flowfuse-secrets
+                key: password
       containers:
       - name: file-storage
         image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}flowforge/file-server:{{ .Chart.AppVersion }}
@@ -70,7 +97,7 @@ spec:
         - name: NODE_ENV
           value: production
         volumeMounts:
-        - name: config
+        - name: configdir
           mountPath: /usr/src/flowforge-file-server/etc
         {{ if eq .Values.forge.fileStore.type "localfs" -}}
         - name: root
@@ -91,7 +118,9 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
-      - name: config
+      - name: configdir
+        emptyDir: {}
+      - name: configtemplate
         configMap: 
           name: flowforge-file-config
       {{ if eq .Values.forge.fileStore.type "localfs" -}}

--- a/helm/flowforge/templates/network-policy.yaml
+++ b/helm/flowforge/templates/network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     app: postgres-service
   name: {{ .Release.Name }}-postgresql
 spec:
-  externalName: {{ .Values.forge.postgres.host }}
+  externalName: {{ .Values.postgresql.host }}
   type: ExternalName
 status:
   loadBalancer: {}

--- a/helm/flowforge/templates/secrets.yaml
+++ b/helm/flowforge/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flowfuse-secrets
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  password: {{ .Values.postgresql.auth.password | b64enc | quote }}
+  postgres-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema#",
     "properties": {
         "forge": {
             "type": "object",
@@ -28,15 +28,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "dbUsername": {
-                    "type": "string"
-                },
-                "dbPassword": {
-                    "type": "string"
-                },
-                "dbName": {
-                    "type": "string"
                 },
                 "email": {
                     "type": "object",
@@ -93,23 +84,6 @@
                 },
                 "localPostgresql": {
                     "type": "boolean"
-                },
-                "postgres": {
-                    "type": "object",
-                    "properties":{
-                        "host": {
-                            "type": "string"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "ssl": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": [
-                        "host"
-                    ]
                 },
                 "projectNamespace": {
                     "type": "string"
@@ -544,21 +518,8 @@
             },
             "required": [
                 "domain",
-                "dbUsername",
-                "dbPassword"
-            ],
-            "if": {
-                "properties": {
-                    "localPostgresql": {
-                        "enum": [ false ]
-                    }
-                }
-            },
-            "then": {
-                "required": [
-                    "postgres"
-                ]
-            }
+                "localPostgresql"
+            ]
         },
         "ingress": {
             "type": "object",
@@ -597,10 +558,68 @@
                 }
             },
             "required": ["serviceAccount"]
+        },
+        "postgresql": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "ssl": {
+                    "type": "boolean"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "database": {
+                            "type": "string"
+                        },
+                        "postgresPassword": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["username", "password", "database"]
+                }
+            }
+        }
+    },
+    "if": {
+        "properties": {
+            "forge": {
+                "properties": {
+                    "localPostgresql": {
+                        "const": false
+                    }
+                }
+            }
+        }
+    },
+    "then": {
+        "properties": {
+            "postgresql": {
+                "required": ["host","auth"]
+            }
+        }
+    },
+    "else": {
+        "properties": {
+            "postgresql": {
+                "required": ["auth"]
+            }
         }
     },
     "required": [
-        "forge"
+        "forge",
+        "postgresql"
     ],
     "title": "Values",
     "type": "object"

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -1,7 +1,4 @@
 forge:
-  dbUsername: forge
-  dbPassword: Zai1Wied
-  dbName: flowforge
   localPostgresql: true
   https: true
   projectNamespace: flowforge
@@ -38,10 +35,6 @@ forge:
       quota: 1048576
       options:
         type: postgres
-        host: flowforge-postgresql
-        username: forge
-        password: Zai1Wied
-        database: ff-context
     podSecurityContext:
       runAsUser: 1000
       runAsGroup: 1000

--- a/test/customizations.yml
+++ b/test/customizations.yml
@@ -3,9 +3,6 @@ forge:
   entryPoint: app.example
   https: true
   localPostgresql: false
-  postgres:
-    host: postgress.example.com
-    port: 5432
   cloudProvider: aws
   managementSelector:
     role: management
@@ -67,13 +64,16 @@ forge:
       type: sequelize
       options:
         type: postgres
-        port: 5432
-        host: flowforge-postgresql
-        username: forge
-        password: password
-        database: ff-context
   branding:
     account:
       signUpTopBanner: HelloWorld
   rate_limits:
     enabled: true
+
+postgresql:
+  host: flowforge-postgresql
+  auth:
+    username: forge
+    password: password
+    database: flowforge
+    postgresPassword: postgres-password


### PR DESCRIPTION
## Description

This PR introduces following features:
* move sensitive data to kubernetes secret
* keep database connection parameters in single configuration block
* update README to match proposed changes

## Related Issue(s)

#283 
#268 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

