### PR TITLE
feat: Add `containerSecurityContext` for each container

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -45,6 +45,7 @@ If using an external PostgreSQL Database you will need to create the database an
  - `forge.clusterRole.name` custom name for the ClusterRole (default `create-pod`)
  - `forge.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the core application container
  - `forge.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the core application pod
+ - `forge.containerSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the core application container
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
@@ -80,6 +81,7 @@ To use STMP to send email
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod
+  - `forge.broker.containerSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker container
 
 ### Telemetry
 
@@ -129,6 +131,7 @@ Enables FlowForge Telemetry
 - `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context (default `1048576`)
 - `forge.fileStore.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the file-server container
 - `forge.fileStore.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the flowforge-file pod
+- `forge.fileStore.containerSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the flowforge-file container
 
 ### Private Certificate Authority
 

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -75,9 +75,7 @@ spec:
           name: mqtt-native
         - containerPort: 1884
           name: mqtt-ws
-        securityContext: 
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+        securityContext: {{- toYaml .Values.forge.broker.containerSecurityContext | nindent 10 }}
         # livenessProbe:
         #   httpGet:
         #     path: /ping.html

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -71,13 +71,11 @@ spec:
           readOnly: true
         {{- end }}
         ports:
-        - containerPort: 3000
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+        - containerPort: 3000        
         {{- if .Values.forge.resources }}
         resources: {{- toYaml .Values.forge.resources | nindent 12 }}
         {{- end }}
+        securityContext: {{- toYaml .Values.forge.containerSecurityContext | nindent 10 }}
       {{- if .Values.forge.registrySecrets }}
       imagePullSecrets:
       {{- range .Values.forge.registrySecrets }}

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -78,9 +78,7 @@ spec:
         {{ end -}}
         ports:
         - containerPort: 3001
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+        securityContext: {{- toYaml .Values.forge.broker.containerSecurityContext | nindent 10 }}
         {{- if .Values.forge.fileStore.resources }}
         resources: {{- toYaml .Values.forge.fileStore.resources | nindent 12 }}
         {{- end }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -270,6 +270,9 @@
                                     }
                                 }
                             }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object"
                         }
                     },
                     "required": [
@@ -397,6 +400,9 @@
                                     }
                                 }
                             }
+                        },
+                        "containerSecurityContext": {
+                            "type": "object"
                         }
                     },
                     "required": [
@@ -539,6 +545,9 @@
                             }
                         }
                     }
+                },
+                "containerSecurityContext": {
+                    "type": "object"
                 }
 
             },

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -27,6 +27,9 @@ forge:
       fsGroup: 1000
       seccompProfile:
         type: RuntimeDefault
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
   fileStore:
     enabled: false
     type: localfs
@@ -73,6 +76,10 @@ forge:
     fsGroup: 1000
     seccompProfile:
       type: RuntimeDefault
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
 
 postgresql:
   auth:


### PR DESCRIPTION
## Description

This PR adds the possibility to configure `containerSecurityContext` for each container created by our helm chart.

## Related Issue(s)

#288 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

