### PR TITLE
feat: Add possibility to configure probes for each pod

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -45,7 +45,9 @@ If using an external PostgreSQL Database you will need to create the database an
  - `forge.clusterRole.name` custom name for the ClusterRole (default `create-pod`)
  - `forge.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the core application container
  - `forge.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the core application pod
-
+ - `forge.livenessProbe` block with [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the core application pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+ - `forge.readinessProbe` block with [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the core application pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+ - `forge.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the core application pod (check [here](#liveness-readiness-and-startup-probes) for more details)
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
   
@@ -80,6 +82,9 @@ To use STMP to send email
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod
+  - `forge.broker.livenessProbe` block with [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+  - `forge.broker.readinessProbe` block with [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+  - `forge.broker.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 
 ### Telemetry
 
@@ -129,6 +134,9 @@ Enables FlowForge Telemetry
 - `forge.fileStore.context.quota` Sets the maximum number of bytes that a project can store in Persistent Context (default `1048576`)
 - `forge.fileStore.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the file-server container
 - `forge.fileStore.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the flowforge-file pod
+- `forge.fileStore.livenessProbe` block with [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+- `forge.fileStore.readinessProbe` block with [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+- `forge.fileStore.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 
 ### Private Certificate Authority
 
@@ -179,4 +187,23 @@ editors:
       eks.amazonaws.com/role-arn: arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}
     create: true
     name: editors
+```
+###  Liveness, readiness and startup probes
+
+Following values can be used to configure the liveness, readiness and startup probes for all pods:
+
+- `initialDelaySeconds` (default `10`) - number of seconds after the container has started before liveness or readiness probes are initiated
+- `periodSeconds` (default `10`) - how often (in seconds) to perform the probe
+- `timeoutSeconds` (default `5`) - number of seconds after which the probe times out
+- `successThreshold` (default `1`) - minimum consecutive successes for the probe to be considered successful after having failed
+- `failureThreshold` (default `3`) - minimum consecutive failures for the probe to be considered failed after having succeeded
+
+Example for readiness probe:
+```yaml
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
 ```

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -78,14 +78,39 @@ spec:
         securityContext: 
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-        # livenessProbe:
-        #   httpGet:
-        #     path: /ping.html
-        #     port: 1884
-        # readinessProbe:
-        #   httpGet:
-        #     path: /ping.html
-        #     port: 1884
+        {{- if .Values.forge.broker.livenessProbe }}
+        livenessProbe:
+          httpGet:
+            path: /ping.html
+            port: 1884
+          initialDelaySeconds: {{ .Values.forge.broker.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.broker.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.broker.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.broker.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.broker.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.broker.readinessProbe }}
+        readinessProbe:
+          httpGet:
+            path: /ping.html
+            port: 1884
+          initialDelaySeconds: {{ .Values.forge.broker.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.broker.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.broker.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.broker.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.broker.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.broker.startupProbe }}
+        startupProbe:
+          httpGet:
+            path: /ping.html
+            port: 1884
+          initialDelaySeconds: {{ .Values.forge.broker.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.broker.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.broker.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.broker.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.broker.startupProbe.failureThreshold }}
+        {{- end }}
         {{- if .Values.forge.broker.resources }}
         resources: {{- toYaml .Values.forge.broker.resources | nindent 12 }}
         {{- end }}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -72,6 +72,39 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3000
+        {{- if .Values.forge.livenessProbe }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: {{ .Values.forge.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.readinessProbe }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: {{ .Values.forge.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.startupProbe }}
+        startupProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: {{ .Values.forge.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.startupProbe.failureThreshold }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -78,6 +78,39 @@ spec:
         {{ end -}}
         ports:
         - containerPort: 3001
+        {{- if .Values.forge.fileStore.livenessProbe }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: {{ .Values.forge.fileStore.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.fileStore.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.fileStore.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.fileStore.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.fileStore.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.fileStore.readinessProbe }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: {{ .Values.forge.fileStore.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.fileStore.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.fileStore.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.fileStore.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.fileStore.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.forge.fileStore.startupProbe }}
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 3001
+          initialDelaySeconds: {{ .Values.forge.fileStore.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.forge.fileStore.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.forge.fileStore.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.forge.fileStore.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.forge.fileStore.startupProbe.failureThreshold }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -270,6 +270,66 @@
                                     }
                                 }
                             }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
                         }
                     },
                     "required": [
@@ -395,6 +455,66 @@
                                             "type": "string"
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "startupProbe": {
+                            "type": "object",
+                            "properties": {
+                                "failureThreshold": {
+                                    "type": "integer"
+                                },
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                },
+                                "periodSeconds": {
+                                    "type": "integer"
+                                },
+                                "successThreshold": {
+                                    "type": "integer"
+                                },
+                                "timeoutSeconds": {
+                                    "type": "integer"
                                 }
                             }
                         }
@@ -539,8 +659,67 @@
                             }
                         }
                     }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
                 }
-
             },
             "required": [
                 "domain",

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -27,6 +27,19 @@ forge:
       fsGroup: 1000
       seccompProfile:
         type: RuntimeDefault
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+
   fileStore:
     enabled: false
     type: localfs
@@ -48,6 +61,7 @@ forge:
       fsGroup: 1000
       seccompProfile:
         type: RuntimeDefault
+
   support:
     enabled: false
 
@@ -73,6 +87,19 @@ forge:
     fsGroup: 1000
     seccompProfile:
       type: RuntimeDefault
+  
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
 
 postgresql:
   auth:


### PR DESCRIPTION
## Description

This PR adds liveness, readiness and startup probes configuration for each pod. Additionally, liveness and readiness checks have been enabled by default for core and broker pods.

## Related Issue(s)

#266 
#263 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

