### PR TITLE
ci: Run checkov against helm chart directory instead of templated yaml

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -106,7 +106,7 @@ jobs:
         if: matrix.tool == 'checkov'
         uses: bridgecrewio/checkov-action@v12
         with:
-          directory: ${{ github.workspace }}
+          directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
           framework: kubernetes
           output_format: cli,sarif

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -101,6 +101,13 @@ jobs:
         uses: azure/setup-helm@v3.5
         with:
           version: v3.13.2
+
+      - name: debug
+        run: |
+          ls -la ${{ github.workspace }}/helm
+          ls -la ${{ github.workspace }}/helm/flowforge
+          ls -la ${{ github.workspace }}/helm/flowforge/ci
+          ls -la ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -113,12 +113,16 @@ jobs:
         if: matrix.tool == 'checkov'
         uses: bridgecrewio/checkov-action@v12.2655.0
         with:
-          directory: ${{ github.workspace }}/helm/flowforge
-          var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
+          directory: ./helm/flowforge
+          var_file: ./helm/flowforge/ci/default-values.yaml
           framework: kubernetes
           output_format: cli,sarif
           output_file_path: console,results.sarif
           soft_fail: true
+
+      - name: debug results
+        run: |
+          cat results.sarif
 
       - name: Template chart
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -113,7 +113,7 @@ jobs:
         if: matrix.tool == 'checkov'
         uses: bridgecrewio/checkov-action@v12.2655.0
         with:
-          directory: ${{ github.workspace }}/helm
+          directory: ${{ github.workspace }}/helm/flowforge
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
           framework: kubernetes
           output_format: cli,sarif

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -101,21 +101,23 @@ jobs:
         uses: azure/setup-helm@v3.5
         with:
           version: v3.13.2
-
-      - name: Template chart
-        run: |
-          helm template flowforge ./helm/flowforge --set forge.domain=example.com > ${{ github.workspace }}/templated_chart.yaml
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'
         uses: bridgecrewio/checkov-action@v12
         with:
           directory: ${{ github.workspace }}
-          file: templated_chart.yaml
+          var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
           framework: kubernetes
           output_format: cli,sarif
           output_file_path: console,results.sarif
           soft_fail: true
+
+      - name: Template chart
+        # temporary disabled due to https://github.com/zegl/kube-score/issues/559
+        if: false
+        run: |
+          helm template flowforge ./helm/flowforge --set forge.domain=example.com > ${{ github.workspace }}/templated_chart.yaml
       
       - name: Install kube-score
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -116,8 +116,8 @@ jobs:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
           framework: helm
-          output_format: cli,sarif
-          output_file_path: console,results.sarif
+          output_format: sarif
+          output_file_path: results.sarif
           soft_fail: true
 
       - name: debug results

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -116,8 +116,8 @@ jobs:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
           framework: helm
-          output_format: sarif
-          output_file_path: results.sarif
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
           soft_fail: true
 
       - name: debug results

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -113,9 +113,9 @@ jobs:
         if: matrix.tool == 'checkov'
         uses: bridgecrewio/checkov-action@v12.2655.0
         with:
-          directory: ./helm/flowforge
-          var_file: ./helm/flowforge/ci/default-values.yaml
-          framework: kubernetes
+          directory: ${{ github.workspace }}/helm
+          var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
+          framework: helm
           output_format: cli,sarif
           output_file_path: console,results.sarif
           soft_fail: true

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -111,7 +111,7 @@ jobs:
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@v12.2655.0
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -101,13 +101,6 @@ jobs:
         uses: azure/setup-helm@v3.5
         with:
           version: v3.13.2
-
-      - name: debug
-        run: |
-          ls -la ${{ github.workspace }}/helm
-          ls -la ${{ github.workspace }}/helm/flowforge
-          ls -la ${{ github.workspace }}/helm/flowforge/ci
-          ls -la ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'
@@ -119,10 +112,6 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           soft_fail: true
-
-      - name: debug results
-        run: |
-          cat results.sarif
 
       - name: Template chart
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559


### PR DESCRIPTION
## Description

This PR changes the way how checkov is performing helm chart scan. Instead of running a scan against a templated yaml file it is running directly in the helm chart directory.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

