### PR TITLE
feat: Add possibility to provide database credentials as an external secret

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -187,24 +187,21 @@ editors:
     name: editors
 ```
 
- ### Postgresql
- - `postgresql.host` - the hostname of an external PostgreSQL database (default not set)
- - `postgresql.port` - the port of an external PostgreSQL database (default `5432`)
- - `postgresql.ssl` - sets the connection to the database to use SSL/TLS (default `false`)
- - `postgresql.auth.username` - the username to use to connect to the database (default `forge`)
- - `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
- - `postgresql.auth.database` - the database to use (default `flowforge`)
- - `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)
- - `postgresql.auth.existingSecret` - the name of an Kubernetes secret object, within same namespace, with database credentials (default not set)
+### Postgresql
+- `postgresql.host` - the hostname of an external PostgreSQL database (default not set)
+- `postgresql.port` - the port of an external PostgreSQL database (default `5432`)
+- `postgresql.ssl` - sets the connection to the database to use SSL/TLS (default `false`)
+- `postgresql.auth.username` - the username to use to connect to the database (default `forge`)
+- `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
+- `postgresql.auth.database` - the database to use (default `flowforge`)
+- `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)
+- `postgresql.auth.existingSecret` - the name of an Kubernetes secret object with database credentials (If `postgresql.auth.existingSecret` is set, `postgresql.auth.password` and `postgresql.auth.postgresPassword` values are ignored; default not set)
 
- Note: External secret must contain the following keys:
-  - `password` - the password to use to connect to the database (equivalent to `postgresql.auth.password` key)
-  - `postgress-password` - the password to use for the postgres user (equivalent to `postgresql.auth.postgresPassword` key)
 
-  Example for creating a external secret via `kubectl`:
-  ```bash
-  kubectl create secret generic database-credentials --from-literal=postgress-password=rootPassword --from-literal=password=applicationPassword
-  ```
+Note: External secret must contain following keys:
+- `password` - the password to use to connect to the database (equivalent to `postgresql.auth.password` key)
+- `postgress-password` - the password to use for the postgres user (equivalent to `postgresql.auth.postgresPassword` key)
+
 
 ###  Liveness, readiness and startup probes
 

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -195,6 +195,16 @@ editors:
  - `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
  - `postgresql.auth.database` - the database to use (default `flowforge`)
  - `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)
+ - `postgresql.auth.existingSecret` - the name of an Kubernetes secret object, within same namespace, with database credentials (default not set)
+
+ Note: External secret must contain the following keys:
+  - `password` - the password to use to connect to the database (equivalent to `postgresql.auth.password` key)
+  - `postgress-password` - the password to use for the postgres user (equivalent to `postgresql.auth.postgresPassword` key)
+
+  Example for creating a external secret via `kubectl`:
+  ```bash
+  kubectl create secret generic database-credentials --from-literal=postgress-password=rootPassword --from-literal=password=applicationPassword
+  ```
 
 ###  Liveness, readiness and startup probes
 

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Get the postgresql secret object name.
+*/}}
+{{- define "forge.secretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+    {{- tpl .Values.postgresql.auth.existingSecret $ -}}
+{{- else -}}
+    {{- printf "%s-%s" (tpl .Release.Name .) "postgresql" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the flowfuse secret object name.
+*/}}
+{{- define "forge.applicationSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+    {{- tpl .Values.postgresql.auth.existingSecret $ -}}
+{{- else -}}
+    {{- printf "flowfuse-secrets" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
-                name: flowfuse-secrets
+                name: {{ include "forge.applicationSecretName" . }}
                 key: password
       containers:
       - name: forge

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -23,11 +23,11 @@ data:
       {{- if .Values.forge.fileStore.context.quota }}
       quota: {{ .Values.forge.fileStore.context.quota }}
       {{- end }}
-      {{- if .Values.forge.fileStore.context.options }}}
+      {{- if .Values.forge.fileStore.context.options }}
       options:
         type: {{ .Values.forge.fileStore.context.options.type }}
         {{- if eq .Values.forge.fileStore.context.options.type "postgres" }}
-        host: {{ .Values.postgresql.host | default "{{ .Release.Name }}-postgresql" }}
+        host: {{ .Values.postgresql.host | default (print .Release.Name "-postgresql") }}
         port: {{ .Values.postgresql.port | default 5432 }}
         username: {{ .Values.postgresql.auth.username }}
         database: ff-context
@@ -87,7 +87,7 @@ spec:
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
-                name: flowfuse-secrets
+                name: {{ include "forge.applicationSecretName" . }}
                 key: password
       containers:
       - name: file-storage

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -37,7 +37,7 @@ spec:
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-                name: {{ .Release.Name }}-postgresql
+                name: {{ include "forge.secretName" . }}
                 key: postgres-password
         volumeMounts:
         - name: upgrade-script

--- a/helm/flowforge/templates/secrets.yaml
+++ b/helm/flowforge/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.postgresql.auth.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ type: Opaque
 data:
   password: {{ .Values.postgresql.auth.password | b64enc | quote }}
   postgres-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
+{{- end -}}


### PR DESCRIPTION
## Description

This PR adds a possibility to provide database credentials as a Kubernetes secret created outside of the Helm chart.

## Related Issue(s)

#290 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

