### PR TITLE
ci: Do not run checkov against subcharts

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
-          skip_path: "*/charts/*"
+          skip_path: "**/charts/**"
           framework: helm
           output_format: cli,sarif
           output_file_path: console,results.sarif

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
+          skip_path: "*/charts/*"
           framework: helm
           output_format: cli,sarif
           output_file_path: console,results.sarif

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
-          skip_path: "**/charts/**"
+          skip_path: /flowforge/charts/
           framework: helm
           output_format: cli,sarif
           output_file_path: console,results.sarif


### PR DESCRIPTION
## Description

This PR excludes sub-charts from the checkov scanning step in the Helm chart validation workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

