### PR TITLE
feat: Add consistent labels to all resources created by the Helm chart

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -44,6 +44,8 @@ For other values please refer to the documentation below.
  - `forge.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the core application pod (check [here](#liveness-readiness-and-startup-probes) for more details) 
  - `forge.containerSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the core application container
  - `forge.logPassthrough` Allows Node-RED Project pods to log in JSON format to standard out, allowing this to be ingested by a logging service (default `false`)
+ - `forge.labels` allows to add custom labels to the core application related objects (e.g. deployment, services, etc.) (default `{}`)
+ - `forge.podLabels` allows to add custom labels to the core application pod (default `{}`)
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
@@ -83,6 +85,8 @@ To use STMP to send email
   - `forge.broker.livenessProbe` block with [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
   - `forge.broker.readinessProbe` block with [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
   - `forge.broker.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+  - `forge.broker.labels` allows to add custom labels to the broker related objects (e.g. deployment, services, etc.) (default `{}`)
+  - `forge.broker.podLabels` allows to add custom labels to the broker pod (default `{}`)
 
 ### Telemetry
 
@@ -136,6 +140,8 @@ Enables FlowForge Telemetry
 - `forge.fileStore.livenessProbe` block with [livenessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 - `forge.fileStore.readinessProbe` block with [readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 - `forge.fileStore.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
+- `forge.fileStore.labels` allows to add custom labels to the file-server related objects (e.g. deployment, services, etc.) (default `{}`)
+- `forge.fileStore.podLabels` allows to add custom labels to the file-server pod (default `{}`)
 
 ### Private Certificate Authority
 

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -1,4 +1,53 @@
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "forge.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "forge.labels" -}}
+helm.sh/chart: {{ include "forge.chart" . }}
+{{ include "forge.commonSelectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* 
+Common Selector Labels
+*/}}
+{{- define "forge.commonSelectorLabels" -}}
+app.kubernetes.io/name: "flowforge"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Forge Selector labels
+*/}}
+{{- define "forge.forgeSelectorLabels" -}}
+{{ include "forge.commonSelectorLabels" . }}
+app.kubernetes.io/component: "forge"
+{{- end }}
+
+{{/*
+Broker Selector labels
+*/}}
+{{- define "forge.brokerSelectorLabels" -}}
+{{ include "forge.commonSelectorLabels" . }}
+app.kubernetes.io/component: "broker"
+{{- end }}
+
+{{/*
+FileStore Selector labels
+*/}}
+{{- define "forge.fileStoreSelectorLabels" -}}
+{{ include "forge.commonSelectorLabels" . }}
+app.kubernetes.io/component: "file-server"
+{{- end }}
+
+{{/*
 Get the postgresql secret object name.
 */}}
 {{- define "forge.secretName" -}}

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flowforge-broker-config
+  labels:
+    {{- include "forge.labels" . | nindent 4 }}
 data:
   mosquitto.conf: |
     per_listener_settings false
@@ -32,6 +34,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flowforge-broker-ping
+  labels:
+    {{- include "forge.labels" . | nindent 4 }}
 data:
   ping.html: |
     <html>
@@ -48,16 +52,22 @@ kind: Deployment
 metadata: 
   name: flowforge-broker
   labels:
-    app: flowforge-broker
+    {{- include "forge.labels" . | nindent 4 }}
+    {{- with .Values.forge.broker.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
-      app: flowforge-broker
+     {{- include "forge.brokerSelectorLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: flowforge-broker
+        {{- include "forge.brokerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.forge.broker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
         {{- toYaml .Values.forge.broker.podSecurityContext | nindent 8 }}
@@ -139,6 +149,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flowforge-broker
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   ports:
   - port: 1883
@@ -150,14 +162,14 @@ spec:
     protocol: TCP
     name: mqtt-ws
   selector:
-    app: flowforge-broker
+    {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flowforge-broker
   labels:
-    app: flowforge-broker
+    {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
   annotations:
   {{- if .Values.ingress.certManagerIssuer }}
     cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flowforge-config
+  labels:
+    {{- include "forge.labels" . | nindent 4 }}
 data:
   flowforge.yml: |
     port: 3000

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -3,16 +3,22 @@ kind: Deployment
 metadata:
   name: flowforge
   labels:
-    app: flowforge
+    {{- include "forge.labels" . | nindent 4 }}
+    {{- with .Values.forge.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: flowforge
+      {{- include "forge.forgeSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: flowforge
+        {{- include "forge.forgeSelectorLabels" . | nindent 8 }}
+        {{- with .Values.forge.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if .Values.forge.telemetry.backend.prometheus.enabled }}
         prometheus.io/scrape: "true"

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flowforge-file-config
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 data:
   flowforge-storage.yml: |
     host: '0.0.0.0'
@@ -48,6 +50,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: file-storage-pvc
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -61,16 +65,22 @@ kind: Deployment
 metadata:
   name: flowforge-file
   labels:
-    app: flowforge-file
+    {{- include "forge.labels" . | nindent 4 }}
+    {{- with .Values.forge.fileStore.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
-      app: flowforge-file
+      {{- include "forge.fileStoreSelectorLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: flowforge-file
+        {{- include "forge.fileStoreSelectorLabels" . | nindent 8 }}
+        {{- with .Values.forge.fileStore.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
         {{- toYaml .Values.forge.fileStore.podSecurityContext | nindent 8 }}
@@ -170,6 +180,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flowforge-file
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   ports:
   - port: 80
@@ -177,5 +189,5 @@ spec:
     protocol: TCP
     name: web
   selector:
-    app: flowforge-file
+    {{- include "forge.fileStoreSelectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: upgrade.sh
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 data:
   upgrade.sh: |
     #!/bin/sh
@@ -18,6 +20,7 @@ kind: Job
 metadata:
   name: {{ .Release.Name }}-db-upgrade
   labels:
+  {{- include "forge.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade,post-install
     "helm.sh/hook-weight": "-5"

--- a/helm/flowforge/templates/namespace.yaml
+++ b/helm/flowforge/templates/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.forge.projectNamespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}

--- a/helm/flowforge/templates/network-policy.yaml
+++ b/helm/flowforge/templates/network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: postgres-service
+  {{- include "forge.labels" . | nindent 4 }}
   name: {{ .Release.Name }}-postgresql
 spec:
   externalName: {{ .Values.postgresql.host }}
@@ -18,6 +18,8 @@ kind: NetworkPolicy
 metadata:
   name: flowforge-database-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
@@ -39,6 +41,8 @@ kind: NetworkPolicy
 metadata:
   name: flowforge-database-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
@@ -50,8 +54,8 @@ spec:
     - from:
       - podSelector:
           matchLabels:
-            app: flowforge
+            {{- include "forge.forgeSelectorLabels" . | nindent 12 }}
       - podSelector:
           matchLabels:
-            app: flowforge-file
+            {{- include "forge.fileStoreSelectorLabels" . | nindent 12 }}
 {{- end }}

--- a/helm/flowforge/templates/private-ca.yaml
+++ b/helm/flowforge/templates/private-ca.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certs"}}
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 data:
   chain.pem: |
 {{ toYaml .Values.forge.privateCA.certs | b64dec | indent 4}}
@@ -13,6 +15,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.forge.privateCA.configMapName }}
   namespace: {{ .Values.forge.projectNamespace | default "flowforge" }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 data:
   chain.pem: |
 {{ toYaml .Values.forge.privateCA.certs | b64dec | indent 4}}

--- a/helm/flowforge/templates/secrets.yaml
+++ b/helm/flowforge/templates/secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: flowfuse-secrets
   namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 type: Opaque
 data:
   password: {{ .Values.postgresql.auth.password | b64enc | quote }}

--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flowforge
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
   {{- if .Values.forge.cloudProvider }}
   {{- if eq .Values.forge.cloudProvider "aws" }}
   annotations:
@@ -18,6 +20,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.editors.serviceAccount.name }}
   namespace: {{ .Values.forge.projectNamespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
   {{- with .Values.editors.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -30,6 +34,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log", "pods/exec", "pods/status"]
@@ -55,6 +61,8 @@ kind: RoleBinding
 metadata:
   name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
   namespace: {{ .Values.forge.projectNamespace }}
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: flowforge

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: forge
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
 spec:
   selector:
-    app: flowforge
+    {{- include "forge.forgeSelectorLabels" . | nindent 6 }}
   ports:
   - protocol: TCP
     port: 80
@@ -15,6 +17,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flowforge-ingress
+  labels:
+  {{- include "forge.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.ingress.certManagerIssuer }}
     cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -307,6 +307,12 @@
                         },
                         "containerSecurityContext": {
                             "type": "object"
+                        },
+                        "podLabels": {
+                            "type": "object"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     },
                     "required": [
@@ -496,6 +502,12 @@
                             }
                         },
                         "containerSecurityContext": {
+                            "type": "object"
+                        },
+                        "podLabels": {
+                            "type": "object"
+                        },
+                        "labels": {
                             "type": "object"
                         }
                     },
@@ -702,6 +714,12 @@
                             "type": "integer"
                         }
                     }
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "labels": {
+                    "type": "object"
                 },
                 "logPassthrough": {
                     "type": "boolean"

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -16,6 +16,8 @@ forge:
     backend:
       prometheus:
         enabled: false
+  labels: {}
+  podLabels: {}
   broker:
     enabled: false
     podSecurityContext:
@@ -36,6 +38,8 @@ forge:
       timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 3
+    labels: {}
+    podLabels: {}
 
   fileStore:
     enabled: false
@@ -57,6 +61,8 @@ forge:
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+    labels: {}
+    podLabels: {}
 
   support:
     enabled: false


### PR DESCRIPTION
## Description

This pull request adds labels to all resources to improve organization and management of the application. The labels are added to the ConfigMaps, Secrets, Namespaces, Jobs, Deployments, Services, Ingresses, NetworkPolicies, ServiceAccounts, ClusterRoles, and RoleBindings. This change ensures that all resources have consistent labelling and makes it easier to identify and manage them.

## Related Issue(s)

#298 
#268 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

