### PR TITLE
ci: Ignore Helm chart related files in images build pipelines

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -12,9 +12,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -12,9 +12,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -12,9 +12,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'helm/**'
+      - '.github/workflows/helm*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
## Description

This pull request adds a configuration ti the container images build and deploy pipelines to ignore changes made in Helm chart-related files. As a result, images will not be built when changes to the Helm chart are the only ones introduced.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

