### PR TITLE
fix: Ensure both priave ca certs configmaps have default names

### DIFF
--- a/helm/flowforge/templates/private-ca.yaml
+++ b/helm/flowforge/templates/private-ca.yaml
@@ -11,7 +11,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.forge.privateCA.configMapName }}
+  name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }} 
   namespace: {{ .Values.forge.projectNamespace | default "flowforge" }}
 data:
   chain.pem: |


### PR DESCRIPTION
While reviewing a different PR I noticed that the Node-RED project namespace version of the configmap didn't have a default name.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

