### PR TITLE
fix: Only run the job if fileStore is enabled

### DIFF
--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.forge.fileStore.context .Values.forge.localPostgresql -}}
+{{- if and .Values.forge.fileStore.enabled .Values.forge.localPostgresql -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
While testing OpenShift I noticed this job was getting run even if the `forge.fileStore.enabled` is false.

It was checking the wrong state

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

