### PR TITLE
feat: Allow to run local postgresql database on ARM nodes

### DIFF
--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -110,6 +110,8 @@ forge:
   logPassthrough: false
 
 postgresql:
+  image:
+    tag: "14.10.0-debian-11-r30"
   auth:
     postgresPassword: Moomiet0
     username: forge


### PR DESCRIPTION
## Description

This pull request updates the local PostgreSQL image tag to `14.10.0-debian-11-r30`.
In result, from now on there is a possibility to schedule local database instance on ARM-based Kubernetes nodes.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/284

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

