### PR TITLE
fix: Rollback selector labels for existing deployments

### DIFF
--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Broker Selector labels
 {{- define "forge.brokerSelectorLabels" -}}
 {{/* 
 {{ include "forge.commonSelectorLabels" . }}
-app.kubernetes.io/component: "broker"}}
+app.kubernetes.io/component: "broker"
 */}}
 app: flowforge-broker
 {{- end }}

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -27,24 +27,34 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Forge Selector labels
 */}}
 {{- define "forge.forgeSelectorLabels" -}}
+{{/*
 {{ include "forge.commonSelectorLabels" . }}
 app.kubernetes.io/component: "forge"
+*/}}
+app: flowforge
 {{- end }}
 
 {{/*
 Broker Selector labels
 */}}
+
 {{- define "forge.brokerSelectorLabels" -}}
+{{/* 
 {{ include "forge.commonSelectorLabels" . }}
-app.kubernetes.io/component: "broker"
+app.kubernetes.io/component: "broker"}}
+*/}}
+app: flowforge-broker
 {{- end }}
 
 {{/*
 FileStore Selector labels
 */}}
 {{- define "forge.fileStoreSelectorLabels" -}}
+{{/*
 {{ include "forge.commonSelectorLabels" . }}
 app.kubernetes.io/component: "file-server"
+*/}}
+app: flowforge-file
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Description

This PR applies old selector labeling approach and creates a workaround for the problem with immutable `spec.selector` field while running the deployment update with helm chart.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

