### PR TITLE
feat: Add default container security context values for broker container

### DIFF
--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -38,6 +38,9 @@ forge:
       timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 3
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
     labels: {}
     podLabels: {}
 


### PR DESCRIPTION
## Description

This pull request adds default container security context values for the broker container. Specifically, it sets `allowPrivilegeEscalation` to false and `readOnlyRootFilesystem` to true. These changes enhance the security of the broker container by preventing privilege escalation and ensuring that the root filesystem is read-only.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

