### PR TITLE
feat: Allow FileStore image to be set

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -128,6 +128,7 @@ Enables FlowForge Telemetry
 ### File Storage
 
 - `forge.fileStore.enabled` (default `false`)
+- `forge.fileStore.image` supply a fully qualified container image for the File Storage app (default `forge.registry`/flowforge/file-server:<App Version>)
 - `forge.fileStore.type` Choice of backends to store files `localfs` or `s3` (default `localfs`)
 - `forge.fileStore.options` Options to pass to the backend storage driver (See [file-server](https://github.com/flowforge/flowforge-file-server) for details)
 - `forge.fileStore.quota` Sets the maximum number of bytes that a project can store as files (default `104857600`)

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -101,7 +101,11 @@ spec:
                 key: password
       containers:
       - name: file-storage
+        {{- if .Values.forge.fileStore.image }}
+        image: {{ .Values.forge.fileStore.image }}
+        {{ else }}
         image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}flowforge/file-server:{{ .Chart.AppVersion }}
+        {{end -}}
         imagePullPolicy: Always
         env:
         - name: NODE_ENV

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -509,6 +509,9 @@
                         },
                         "labels": {
                             "type": "object"
+                        },
+                        "image": {
+                            "type": "string"
                         }
                     },
                     "required": [


### PR DESCRIPTION
## Description
Allows overriding the file store container
<!-- Describe your changes in detail -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

