### PR TITLE
fix: Update liveness and readiness probe timeout values for broker pod

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -218,11 +218,11 @@ Note: External secret must contain following keys:
 
 Following values can be used to configure the liveness, readiness and startup probes for all pods:
 
-- `initialDelaySeconds` (default `10`) - number of seconds after the container has started before liveness or readiness probes are initiated
-- `periodSeconds` (default `10`) - how often (in seconds) to perform the probe
-- `timeoutSeconds` (default `5`) - number of seconds after which the probe times out
-- `successThreshold` (default `1`) - minimum consecutive successes for the probe to be considered successful after having failed
-- `failureThreshold` (default `3`) - minimum consecutive failures for the probe to be considered failed after having succeeded
+- `initialDelaySeconds` - number of seconds after the container has started before liveness or readiness probes are initiated
+- `periodSeconds` - how often (in seconds) to perform the probe
+- `timeoutSeconds` - number of seconds after which the probe times out
+- `successThreshold` - minimum consecutive successes for the probe to be considered successful after having failed
+- `failureThreshold` - minimum consecutive failures for the probe to be considered failed after having succeeded
 
 Example for readiness probe:
 ```yaml

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -29,13 +29,13 @@ forge:
     livenessProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
-      timeoutSeconds: 5
+      timeoutSeconds: 15
       successThreshold: 1
-      failureThreshold: 3
+      failureThreshold: 5
     readinessProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
-      timeoutSeconds: 5
+      timeoutSeconds: 15
       successThreshold: 1
       failureThreshold: 3
     containerSecurityContext:


### PR DESCRIPTION
## Description

This pull request updates the liveness and readiness probe timeout values for the broker pod. The timeoutSeconds for both probes has been increased from 5 to 15, and the failureThreshold has been increased from 3 to 5. This change ensures that the broker pod has enough time to respond to the probes before being marked as unhealthy.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

