### PR TITLE
feat: Add possibility to configure unique annotations for each ingress object

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -87,6 +87,12 @@ To use STMP to send email
   - `forge.broker.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
   - `forge.broker.labels` allows to add custom labels to the broker related objects (e.g. deployment, services, etc.) (default `{}`)
   - `forge.broker.podLabels` allows to add custom labels to the broker pod (default `{}`)
+  - `forge.broker.ingress.annotations` broker ingress annotations (default is `{}`)
+
+`forge.broker.ingress.annotations` values can contain the following tokens that will be replaced as follows:
+
+  - `{{ instanceHost }}` replaced by the hostname of the instance
+  - `{{ serviceName }}` replaced by the service name of the instance
 
 ### Telemetry
 

--- a/helm/flowforge/templates/broker-ingress.yaml
+++ b/helm/flowforge/templates/broker-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.forge.broker.enabled -}}
-{{- $brokerHostname := or (.Values.forge.entryPoint) (printf "%s%s" "mqtt." .Values.forge.domain) -}}
+{{- $brokerHostname := (printf "%s%s" "mqtt." .Values.forge.domain) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/flowforge/templates/broker-ingress.yaml
+++ b/helm/flowforge/templates/broker-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.forge.broker.enabled -}}
+{{- $brokerHostname := or (.Values.forge.entryPoint) (printf "%s%s" "mqtt." .Values.forge.domain) -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: flowforge-broker
+  labels:
+    {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
+  annotations:
+  {{- if .Values.ingress.certManagerIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}
+  {{- end }}
+  {{- if and .Values.forge.broker.enabled .Values.forge.broker.ingress (hasKey .Values.forge.broker.ingress "annotations") }}
+{{ toYaml .Values.forge.broker.ingress.annotations | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
+  {{- end }}
+spec:
+  {{- if $.Values.ingress.className }}
+  ingressClassName: {{ $.Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: mqtt.{{ .Values.forge.domain }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: flowforge-broker
+                port:
+                  number: 1884
+  {{- if .Values.ingress.certManagerIssuer }}
+  tls:
+  - hosts:
+    - mqtt.{{ .Values.forge.domain }}
+    secretName: mqtt.{{ .Values.forge.domain }}
+  {{- end }}
+{{- end }}

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.forge.broker.enabled -}}
-{{- $brokerHostname := or (.Values.forge.entryPoint) (printf "%s%s" "mqtt." .Values.forge.domain) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -163,53 +162,4 @@ spec:
     name: mqtt-ws
   selector:
     {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: flowforge-broker
-  labels:
-    {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
-  annotations:
-  {{- if .Values.ingress.certManagerIssuer }}
-    cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}
-  {{- end }}
-  {{- if .Values.ingress.annotations }}
-{{ toYaml .Values.ingress.annotations | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
-  {{- end }}
-spec:
-  {{- if $.Values.ingress.className }}
-  ingressClassName: {{ $.Values.ingress.className }}
-  {{- end }}
-  rules:
-    - host: mqtt.{{ .Values.forge.domain }}
-      http:
-        paths:
-          - pathType: Prefix
-            path: /
-            backend:
-              service:
-                name: flowforge-broker
-                port:
-                  number: 1884
-  {{- if .Values.ingress.certManagerIssuer }}
-  tls:
-  - hosts:
-    - mqtt.{{ .Values.forge.domain }}
-    secretName: mqtt.{{ .Values.forge.domain }}
-  {{- end }}
-# ---
-# apiVersion: v1
-# kind: Service
-# metadata:
-#   name: flowforge-broker-native
-# spec:
-#   type: LoadBalancer
-#   ports:
-#   - port: 1883
-#     targetPort: mqtt-native
-#     protocol: TCP
-#     name: mqtt-native
-#   selector:
-#     app: flowforge-broker
 {{- end -}}

--- a/helm/flowforge/tests/ingress_test.yaml
+++ b/helm/flowforge/tests/ingress_test.yaml
@@ -1,0 +1,107 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test forge ingress objects
+set:
+  forge.domain: "chart-unit-tests.com"
+tests:
+  - it: should create forge ingress object
+    template: service-ingress.yaml
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          name: flowforge-ingress
+          apiVersion: networking.k8s.io/v1
+          any: true
+  - it: should create forge and broker ingress objects
+    set:
+      forge.broker.enabled: true
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          name: flowforge-ingress
+          apiVersion: networking.k8s.io/v1
+          any: true
+        template: service-ingress.yaml
+      - containsDocument:
+          kind: Ingress
+          name: flowforge-broker
+          apiVersion: networking.k8s.io/v1
+          any: true
+        template: broker-ingress.yaml
+  - it: should create forge ingress object with annotations
+    template: service-ingress.yaml
+    documentSelector: 
+      path: metadata.name
+      value: flowforge-ingress   
+    set:
+      ingress.annotations:
+        customForgeAnnotation: "true"
+    asserts:
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations.customForgeAnnotation
+          value: "true"
+  - it: should create forge ingress object without annotations
+    template: service-ingress.yaml
+    documentSelector: 
+      path: metadata.name
+      value: flowforge-ingress
+    asserts:
+      - isNullOrEmpty:
+          path: metadata.annotations
+  - it: should create broker ingress object with annotations
+    templates: 
+      - broker-ingress.yaml
+    set:
+      forge.broker:
+        enabled: true
+        ingress:
+          annotations:
+            customBrokerAnnotation: "true"
+    asserts:
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations.customBrokerAnnotation
+          value: "true"
+  - it: should create broker ingress object without annotations
+    templates: 
+    - broker-ingress.yaml
+    set:
+      ingress.annotations:
+        customForgeAnnotation: "true"
+      forge.broker:
+        enabled: true
+    asserts:
+      - isNullOrEmpty:
+          path: metadata.annotations
+  - it: should create forge and broker ingress object with different annotations
+    set:
+      forge.broker:
+        enabled: true
+        ingress:
+          annotations:
+            customBrokerAnnotation: "true"
+      ingress.annotations:
+        customForgeAnnotation: "true"
+    asserts:
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+        template: broker-ingress.yaml
+      - equal:
+          path: metadata.annotations.customBrokerAnnotation
+          value: "true"
+        template: broker-ingress.yaml
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+        template: service-ingress.yaml
+        documentSelector: 
+          path: metadata.name
+          value: flowforge-ingress 
+      - equal:
+          path: metadata.annotations.customForgeAnnotation
+          value: "true"
+        template: service-ingress.yaml
+        documentSelector: 
+          path: metadata.name
+          value: flowforge-ingress 

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -313,6 +313,15 @@
                         },
                         "labels": {
                             "type": "object"
+                        },
+                        "ingress": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "minProperties": 0
+                                }
+                            }
                         }
                     },
                     "required": [

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -43,6 +43,7 @@ forge:
       readOnlyRootFilesystem: true
     labels: {}
     podLabels: {}
+    ingress.annotations: {}
 
   fileStore:
     enabled: false


### PR DESCRIPTION
## Description

This pull request adds a possibility to configure unique annotations for forge and broker ingresses.
Additionally it also:
- moves broker ingress to separate file
- introduces basic unit tests for ingress objects created by the Helm chart
- updates documentation

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/216

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

