### PR TITLE
ci: Test helm chart upgrade process against version in `main` branch

### DIFF
--- a/.github/configs/chart-testing.yaml
+++ b/.github/configs/chart-testing.yaml
@@ -1,3 +1,5 @@
+remote: origin
+target-branch: main
 charts:
   - ./helm/flowforge
 validate-maintainers: false

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -54,7 +54,7 @@ jobs:
           done
 
       - name: Run chart-testing (install and upgrade)
-        run: ct install --config ./.github/configs/chart-testing.yaml
+        run: ct install --upgrade --config ./.github/configs/chart-testing.yaml
   
   validate:
     name: Validate chart against kubernetes API

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -53,7 +53,7 @@ jobs:
             kubectl label --overwrite $node "role=management"
           done
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing (install and upgrade)
         run: ct install --config ./.github/configs/chart-testing.yaml
   
   validate:


### PR DESCRIPTION
## Description

This PR extends the helm chart verification process by adding the upgrade step to the workflow. As a result, the helm chart from the particular PR is used for the upgrade process against deployment created with the helm chart from the `main` branch.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/315

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

