### PR TITLE
ci: Bump workflows to `v0.5.0`

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.5.0
     with:
       image_name: 'file-server'
       package_dependencies: |
@@ -44,7 +44,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.5.0
     with:
       image_name: 'file-server'
     secrets:
@@ -54,7 +54,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: stage
       service_name: 'file-server'
@@ -71,7 +71,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: production
       service_name: 'file-server'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.5.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -45,7 +45,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.5.0
     with:
       image_name: 'forge-k8s'
     secrets:
@@ -55,7 +55,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to staging environment
     needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -72,7 +72,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Deploy to production environment
     needs: [build-multi-architecture, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: production
       service_name: 'forge-k8s'

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-302:
     name: Build 3.0.2 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.5.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
@@ -45,7 +45,7 @@ jobs:
   build-302-multi-architecture:
     name: Build multi-architecture container image
     needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.5.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.0.2-'
@@ -55,7 +55,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -73,7 +73,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: production
       service_name: 'node-red'
@@ -90,7 +90,7 @@ jobs:
 
   build-223:
     name: Build 2.2.3 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.5.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-2.2.x
@@ -106,7 +106,7 @@ jobs:
   build-223-multi-architecture:
     name: Build multi-architecture container image
     needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.5.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '2.2.3-'
@@ -116,7 +116,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -134,7 +134,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: production
       service_name: 'node-red'
@@ -151,7 +151,7 @@ jobs:
 
   build-310:
     name: Build 3.1.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.5.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-3.1
@@ -167,7 +167,7 @@ jobs:
   build-310-multi-architecture:
     name: Build multi-architecture container image
     needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.5.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.1.x-'
@@ -177,7 +177,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -195,7 +195,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.4.1
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.5.0
     with:
       environment: production
       service_name: 'node-red'


### PR DESCRIPTION
## Description

This pull request updates the workflows to version `v0.5.0`. It includes the following changes:

- Bump the version of the build_container_image workflow to `v0.5.0`

- Bump the version of the merge_multiarch_images workflow to `v0.5.0`

- Bump the version of the deploy_container_image workflow to `v0.5.0`

These updates ensure that the latest versions of the workflows are being used.

## Related Issue(s)

https://github.com/FlowFuse/github-actions-workflows/issues/31

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

