### PR TITLE
ci: Wait for forge app public image to become available 

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Wait for forge application public image
         run: |
-          IMAGE="flowfuse/forge-k8s:${{ env.APP_VERSION }}"
+          IMAGE="flowfuse/forge-k8s"
           TAG=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}')
           ATTEMPTS=0
           until docker pull $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -59,13 +59,13 @@ jobs:
           IMAGE="flowfuse/forge-k8s"
           TAG=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}')
           ATTEMPTS=0
-          until docker inspect $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
+          until docker manifest inspect $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
             ATTEMPTS=$((ATTEMPTS+1))
             echo "Attempt $ATTEMPTS failed! Trying again in 30 seconds..."
             sleep 30
           done
           if [ $ATTEMPTS -eq 10 ]; then
-            echo "Failed to inspect $IMAGE:$TAG after $ATTEMPTS attempts!"
+            echo "Failed to inspect remote $IMAGE:$TAG after $ATTEMPTS attempts!"
             exit 1
           fi
 

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -53,6 +53,7 @@ jobs:
             kubectl label --overwrite $node "role=management"
           done
 
+
       - name: Wait for forge application public image
         run: |
           IMAGE="flowfuse/forge-k8s:${{ env.APP_VERSION }}"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Wait for application public image
         uses: PaulLesur/wait-docker-image-github-action@v1.0
         with:
-          image: flowfuse/forge-k8s
+          image: docker.io/flowfuse/forge-k8s
           tag: ${{ env.APP_VERSION }}
           timeout: 300
           fail-on-timeout: true

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -52,6 +52,18 @@ jobs:
           for node in $(kubectl get nodes -o name); do
             kubectl label --overwrite $node "role=management"
           done
+      
+      - name: Set application version
+        run: |
+          echo APP_VERSION=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}') >> $GITHUB_ENV
+
+      - name: Wait for application public image
+        uses: PaulLesur/wait-docker-image-github-action@v1.0
+        with:
+          image: forge-k8s
+          tag: ${{ env.APP_VERSION }}
+          timeout: 300
+          fail-on-timeout: true
 
       - name: Run chart-testing (install and upgrade)
         run: ct install --upgrade --config ./.github/configs/chart-testing.yaml

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -52,18 +52,21 @@ jobs:
           for node in $(kubectl get nodes -o name); do
             kubectl label --overwrite $node "role=management"
           done
-      
-      - name: Set application version
-        run: |
-          echo APP_VERSION=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}') >> $GITHUB_ENV
 
-      - name: Wait for application public image
-        uses: PaulLesur/wait-docker-image-github-action@v1.0
-        with:
-          image: docker.io/flowfuse/forge-k8s
-          tag: ${{ env.APP_VERSION }}
-          timeout: 300
-          fail-on-timeout: true
+      - name: Wait for forge application public image
+        run: |
+          IMAGE="flowfuse/forge-k8s:${{ env.APP_VERSION }}"
+          TAG=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}')
+          ATTEMPTS=0
+          until docker pull $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
+            ATTEMPTS=$((ATTEMPTS+1))
+            echo "Attempt $ATTEMPTS failed! Trying again in 30 seconds..."
+            sleep 30
+          done
+          if [ $ATTEMPTS -eq 10 ]; then
+            echo "Failed to pull $IMAGE:$TAG after $ATTEMPTS attempts!"
+            exit 1
+          fi
 
       - name: Run chart-testing (install and upgrade)
         run: ct install --upgrade --config ./.github/configs/chart-testing.yaml

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Wait for application public image
         uses: PaulLesur/wait-docker-image-github-action@v1.0
         with:
-          image: forge-k8s
+          image: flowfuse/forge-k8s
           tag: ${{ env.APP_VERSION }}
           timeout: 300
           fail-on-timeout: true

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -53,7 +53,6 @@ jobs:
             kubectl label --overwrite $node "role=management"
           done
 
-
       - name: Wait for forge application public image
         run: |
           IMAGE="flowfuse/forge-k8s"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -59,13 +59,13 @@ jobs:
           IMAGE="flowfuse/forge-k8s"
           TAG=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}')
           ATTEMPTS=0
-          until docker pull $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
+          until docker inspect $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
             ATTEMPTS=$((ATTEMPTS+1))
             echo "Attempt $ATTEMPTS failed! Trying again in 30 seconds..."
             sleep 30
           done
           if [ $ATTEMPTS -eq 10 ]; then
-            echo "Failed to pull $IMAGE:$TAG after $ATTEMPTS attempts!"
+            echo "Failed to inspect $IMAGE:$TAG after $ATTEMPTS attempts!"
             exit 1
           fi
 


### PR DESCRIPTION
## Description

This PR adds a forge app image validation step to the Helm linting pipeline. It verifies if the latest application container image is available in the Docker Hub before executing the chart-testing tool.
This approach should solve the problem of unavailable application contaimer image during the release process.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/318

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

