### PR TITLE
fix: Drop all capabilities for init container

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             mountPath: /tmpl
           - name: configdir
             mountPath: /config
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
         env:
           - name: PGPASSWORD
             valueFrom:


### PR DESCRIPTION
## Description

This PR adds a drop of all capabilities for init container. The main reasons of not making this parameter configurable are:
* init container does single, simple task which does not require capabilities to be modified 
* I am pretty sure that init container is a short term solution of how we are passing configuration parameters to the forge app and will not stay with us for a long time

I have tested such configuration locally and init container does its job as expected.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/320
https://github.com/FlowFuse/CloudProject/issues/319

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

