### PR TITLE
feat: Drop all forge container capabilities

### DIFF
--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -97,6 +97,9 @@ forge:
   containerSecurityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
   livenessProbe:
     initialDelaySeconds: 10


### PR DESCRIPTION
## Description

This pull request adds the capability to drop all privileges in the container's security context. This is done by adding the "drop" capabilities to the containerSecurityContext section of the forge configuration. This change ensures that the container runs with minimal privileges, enhancing its security.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/320
https://github.com/FlowFuse/CloudProject/issues/319

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

