### PR TITLE
fix: db-upgrade job image URL

### DIFF
--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: add-context-db
-        image: {{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}/{{ .Values.postgresql.image.tag }}
+        image: {{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
         env:
         - name: PGPASSWORD
           valueFrom:


### PR DESCRIPTION
## Description

This pull request fixes the image URL for the db-upgrade job in the Hlem chart. The image URL was incorrectly specified in the previous version, and this PR corrects it to use the correct format.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

