### PR TITLE
ci: Allow to manually trigger Helm chart release pipeline

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,15 +1,10 @@
 name: Release Helm Chart
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'helm/**'
+  workflow_dispatch:
 
 jobs:
   release:
-    if: false
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR adds a possibility to manually trigger FlowFuse Helm chart release pipeline. Additionaly, it removes automatic pipeline trigger on push to the main branch. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

