### PR TITLE
feat: All containers should use read-only file system 

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           - name: configdir
             mountPath: /config
         securityContext:
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - ALL

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -56,6 +56,11 @@ spec:
               secretKeyRef:
                 name: {{ include "forge.applicationSecretName" . }}
                 key: password
+        securityContext:
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: file-storage
         {{- if .Values.forge.fileStore.image }}


### PR DESCRIPTION
## Description

This PR sets missing `readOnlyRootFilesystem` on all containers created by the Helm chart. These changes ensure that the container runs with a read-only root filesystem for improved security.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/261

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

