### PR TITLE
feat: Add imagePullPolicy to initContainers

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       initContainers:
       - name: config
         image: "ruby:2.7-slim"
+        imagePullPolicy: Always
         command: ['sh', '-c', 'erb /tmpl/flowforge.yml > /config/flowforge.yml']
         volumeMounts:
           - name: configtemplate

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -44,6 +44,7 @@ spec:
       initContainers:
       - name: config
         image: "ruby:2.7-slim"
+        imagePullPolicy: Always
         command: ['sh', '-c', 'erb /tmpl/flowforge-storage.yml > /config/flowforge-storage.yml' ]
         volumeMounts:
           - name: configtemplate


### PR DESCRIPTION
## Description

This PR adds the `imagePullPolicy: Always` property to the `initContainers` in the deployment YAML file. This ensures that the initContainers always pull the latest image when deploying the application.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/260

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

