### PR TITLE
fix: Remove helm annotation hooks from `upgrade-db` job

### DIFF
--- a/helm/flowforge/templates/job-upgrade-db.yaml
+++ b/helm/flowforge/templates/job-upgrade-db.yaml
@@ -21,11 +21,8 @@ metadata:
   name: {{ .Release.Name }}-db-upgrade
   labels:
   {{- include "forge.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-upgrade,post-install
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       name:


### PR DESCRIPTION
## Description

This PR removes hooks from the `upgrade-db` job. 
Due to the configuration of these hooks the job, responsible for creating an additional database, was executed after helm chart installation/upgrade was completed. Since `fileServer` application relies on this additional database, it was entering a crashing loop waiting for the database to be available. In conjunction with `--atomic` or `--wait` flag, this could lead to the installation failure.
This change assures that the job is created as a part of the helm chart installation.
Additionally, it adds TTL for the job.

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

