### PR TITLE
ci: Introduce Node-RED `4.0.0-beta` container images

### DIFF
--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -209,3 +209,64 @@ jobs:
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
+
+  build-40:
+    name: Build 4.0.x container images
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.8.0
+    with:
+      image_name: 'node-red'
+      dockerfile_path: Dockerfile-4.0
+      image_tag_prefix: '4.0.x-'
+      package_dependencies: |
+        @flowforge/nr-project-nodes
+      build_context: 'node-red-container'
+      npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
+      scan_image: true
+    secrets:
+      npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+  build-40-multi-architecture:
+    name: Build multi-architecture container image
+    needs: build-40
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.8.0
+    with:
+      image_name: 'node-red'
+      image_tag_prefix: '4.0.x-'
+    secrets:
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+  upload-40-stage:
+    name: Upload image to staging ECR
+    if: github.ref_name == 'main'
+    needs: build-40-multi-architecture
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.8.0
+    with:
+      environment: stage
+      service_name: 'node-red'
+      deployment_name: 'node-red'
+      container_name: 'node-red'
+      deploy: false
+      image: ${{ needs.build-40-multi-architecture.outputs.image }}
+      image_tag_prefix: '4.0.x-'
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
+  upload-40-prod:
+    name: Upload image to production ECR
+    if: github.ref_name == 'main'
+    needs: build-40-multi-architecture
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.8.0
+    with:
+      environment: production
+      service_name: 'node-red'
+      deployment_name: 'node-red'
+      container_name: 'node-red'
+      deploy: false
+      image: ${{ needs.build-40-multi-architecture.outputs.image }}
+      image_tag_prefix: '4.0.x-'
+    secrets:
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,0 +1,35 @@
+FROM nodered/node-red:4.0.0-beta.1-18
+
+ARG REGISTRY
+ARG REGISTRY_TOKEN
+ARG BUILD_TAG=latest
+RUN if [[ ! -z "$REGISTRY_TOKEN" ]]; then echo "//$REGISTRY/:_authToken=$REGISTRY_TOKEN" >> ~/.npmrc ; fi
+RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowfuse:registry "https://$REGISTRY"; fi
+
+COPY healthcheck.js /healthcheck.js
+
+COPY package.json /data
+WORKDIR /data
+RUN mkdir node_modules
+RUN npm install
+
+USER root
+
+WORKDIR /usr/src/flowforge-nr-launcher
+RUN chown -R node-red:node-red /usr/src/flowforge-nr-launcher
+
+USER node-red
+RUN npm install @flowfuse/nr-launcher@${BUILD_TAG}
+
+USER root
+RUN chmod -R g+w /data/* /data/.npm/* 
+RUN chown -R node-red:root /data/* /data/.npm/* 
+
+USER node-red
+
+ENV NODE_PATH=/usr/src/node-red
+ENV HOME=/usr/src/node-red
+
+EXPOSE 2880
+
+ENTRYPOINT ["./node_modules/.bin/flowfuse-node-red", "-p", "2880", "-n", "/usr/src/node-red"]

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,4 +1,4 @@
-FROM nodered/node-red-dev:4.0.0-beta.1-18
+FROM nodered/node-red-dev:4.0.0-beta.1
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,4 +1,4 @@
-FROM nodered/node-red:4.0.0-beta.1-18
+FROM nodered/node-red-dev:4.0.0-beta.1-18
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN

--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,4 +1,4 @@
-FROM nodered/node-red-dev:4.0.0-beta.1
+FROM nodered/node-red-dev:v4.0.0-beta.1
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
## Description

This pull request adds a Dockerfile for Node-RED 4.0.0-beta.1-18 and build/upload workflows for building and uploading Node-RED 4.0.x container images.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/350

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

