### PR TITLE
ci: Add Node-RED 4.0 public container build job into existing workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -185,6 +185,42 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
 
+  build_nodered_container_40:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'flowfuse/helm'
+          path: 'helm'
+      - name: Docker Meta Data
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          tags: |
+            type=raw,enable=true,priority=200,prefix=,suffix=-4.0.x,value=${{ github.event.inputs.version }}
+          flavor: |
+            latest=false
+          images: |
+            flowforge/node-red
+            flowfuse/node-red
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: docker login
+        uses: docker/login-action@v3
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and push FlowForge Application container
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: helm/node-red-container
+          file: helm/node-red-container/Dockerfile-4.0
+          platforms: linux/amd64, linux/arm64, linux/arm/v7 
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+
   build_file_server_container:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This PR adds a job responsible for creating and publishing on Docker Hub a container image with Node-RED `4.0.0-beta`.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/350

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

