### PR TITLE
fix: Only build NR 4.0 for amd64 and arm64

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -217,7 +217,7 @@ jobs:
         with:
           context: helm/node-red-container
           file: helm/node-red-container/Dockerfile-4.0
-          platforms: linux/amd64, linux/arm64, linux/arm/v7 
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
32bit ARM builds failed to build for Node-RED 4.0 so their are no parent builds


