### PR TITLE
chore: Update Dockerfile-3.1 for NR 3.1.8

### DIFF
--- a/node-red-container/Dockerfile-3.1
+++ b/node-red-container/Dockerfile-3.1
@@ -1,4 +1,4 @@
-FROM nodered/node-red:3.1.7-18
+FROM nodered/node-red:3.1.8-18
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
Upstream docker images are still building as I type this but should be available shortly.