### PR TITLE
feat: Add possibility to customize domain for MQTT broker

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -85,6 +85,7 @@ To use STMP to send email
   - `forge.broker.enabled` (default `false`)
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://flowforge-broker.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
+  - `forge.broker.domain` the domain the broker will be hosted on (default `mgtt.[forge.domain]`)
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -85,7 +85,7 @@ To use STMP to send email
   - `forge.broker.enabled` (default `false`)
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://flowforge-broker.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
-  - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mgtt.[forge.domain]`)
+  - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mqtt.[forge.domain]`)
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -86,7 +86,6 @@ To use STMP to send email
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://flowforge-broker.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
   - `forge.broker.hostname` The custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mgtt.[forge.domain]`)
-  - `forge.broker.hostname` The custom Fully Qualified Domain Name (FQDN) where the broker will be hosted. By default, it's set to `mqtt.[forge.domain]`. Please ensure that the hostname is valid and correctly configured in your DNS settings to avoid any connectivity issues.
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -85,7 +85,8 @@ To use STMP to send email
   - `forge.broker.enabled` (default `false`)
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://flowforge-broker.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
-  - `forge.broker.domain` the domain the broker will be hosted on (default `mgtt.[forge.domain]`)
+  - `forge.broker.hostname` The custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mgtt.[forge.domain]`)
+  - `forge.broker.hostname` The custom Fully Qualified Domain Name (FQDN) where the broker will be hosted. By default, it's set to `mqtt.[forge.domain]`. Please ensure that the hostname is valid and correctly configured in your DNS settings to avoid any connectivity issues.
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -24,7 +24,7 @@ For other values please refer to the documentation below.
 
  - `forge.image` supply a fully qualified container image for the forge app (default `forge.registry`/flowforge/forge-k8s:<App Version>)
  - `forge.domain` the domain instances will be hosted on
- - `forge.entryPoint` if the admin app is hosted on a different domain
+ - `forge.entryPoint` the custom Fully Qualified Domain Name (FQDN) for the admin app (default `forge.[forge.domain]`)
  - `forge.https` is the Forge App accessed via HTTPS (default `true`)
  - `forge.registry` the hostname for the container registry to find Project stacks (default Docker Hub)
  - `forge.localPostrgresql` Deploy a PostgreSQL v14 Database into Kubernetes cluster (default `true`)
@@ -85,7 +85,7 @@ To use STMP to send email
   - `forge.broker.enabled` (default `false`)
   - `forge.broker.url` URL to access the broker from inside the cluster (default `mqtt://flowforge-broker.[namespace]:1883`)
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
-  - `forge.broker.hostname` The custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mgtt.[forge.domain]`)
+  - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mgtt.[forge.domain]`)
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
   - `forge.broker.podSecurityContext` allows to configure [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the broker pod

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -140,8 +140,8 @@ postgres-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote 
 Configure broker domain
 */}}
 {{- define "forge.brokerDomain" -}}
-{{- if (((.Values.forge).broker).domain) -}}
-    {{ .Values.forge.broker.domain }}
+{{- if (((.Values.forge).broker).hostname) -}}
+    {{ .Values.forge.broker.hostname }}
 {{- else -}}
     {{ printf "%s.%s" "mqtt" .Values.forge.domain }}
 {{- end -}}

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -134,3 +134,15 @@ password: {{ .Values.postgresql.auth.password | b64enc | quote }}
 postgres-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Configure broker domain
+*/}}
+{{- define "forge.brokerDomain" -}}
+{{- if (((.Values.forge).broker).domain) -}}
+    {{ .Values.forge.broker.domain }}
+{{- else -}}
+    {{ printf "%s.%s" "mqtt" .Values.forge.domain }}
+{{- end -}}
+{{- end -}}

--- a/helm/flowforge/templates/broker-ingress.yaml
+++ b/helm/flowforge/templates/broker-ingress.yaml
@@ -11,14 +11,14 @@ metadata:
     cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerIssuer }}
   {{- end }}
   {{- if and .Values.forge.broker.enabled .Values.forge.broker.ingress (hasKey .Values.forge.broker.ingress "annotations") }}
-{{ toYaml .Values.forge.broker.ingress.annotations | replace "{{ instanceHost }}" $brokerHostname | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
+{{ toYaml .Values.forge.broker.ingress.annotations | replace "{{ instanceHost }}" "{{ include forge.brokerDomain . }}" | replace "{{ serviceName }}" "flowforge-broker" | indent 4 }}
   {{- end }}
 spec:
   {{- if $.Values.ingress.className }}
   ingressClassName: {{ $.Values.ingress.className }}
   {{- end }}
   rules:
-    - host: mqtt.{{ .Values.forge.domain }}
+    - host: {{ include "forge.brokerDomain" . }}
       http:
         paths:
           - pathType: Prefix
@@ -31,7 +31,7 @@ spec:
   {{- if .Values.ingress.certManagerIssuer }}
   tls:
   - hosts:
-    - mqtt.{{ .Values.forge.domain }}
-    secretName: mqtt.{{ .Values.forge.domain }}
+    - {{ include "forge.brokerDomain" . }}
+    secretName: {{ include "forge.brokerDomain" . }}
   {{- end }}
 {{- end }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -129,7 +129,7 @@ data:
       {{ if .Values.forge.broker.public_url -}}
       public_url: {{ .Values.forge.broker.public_url }}
       {{ else -}}
-      public_url: ws{{- if .Values.forge.https -}}s{{- end -}}://mqtt.{{ .Values.forge.domain }}
+      public_url: ws{{- if .Values.forge.https -}}s{{- end -}}://{{ include "forge.brokerDomain" . }}
       {{ end -}}
     {{- end }}
     logging:

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -207,6 +207,9 @@
                         "public_url": {
                             "type": "string"
                         },
+                        "domain": {
+                            "type": "string"
+                        },
                         "affinity": {
                             "type": "object"
                         },

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -207,7 +207,7 @@
                         "public_url": {
                             "type": "string"
                         },
-                        "domain": {
+                        "hostname": {
                             "type": "string"
                         },
                         "affinity": {


### PR DESCRIPTION
## Description

This PR adds the `forge.broker.domain` configuration option to allow running the MQTT broker on a custom domain. It also includes updates to the chart's schema and the documentation update.
The example of the FlowFuse Platform running with the broker on custom domain is available [here](https://3674.flowfuse.dev/).

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/295

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

