### PR TITLE
fix: Bind resources to the namespace

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -119,7 +119,7 @@ jobs:
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'
-        uses: bridgecrewio/checkov-action@v12.2655.0
+        uses: bridgecrewio/checkov-action@v12
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
@@ -128,6 +128,8 @@ jobs:
           output_format: cli,sarif
           output_file_path: console,results.sarif
           soft_fail: true
+        env: 
+          HELM_NAMESPACE: no-default-namespace
 
       - name: Template chart
         # temporary disabled due to https://github.com/zegl/kube-score/issues/559

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flowforge-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "forge.labels" . | nindent 4 }}
 data:

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flowforge
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "forge.labels" . | nindent 4 }}
     {{- with .Values.forge.labels }}

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: file-storage-pvc
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 spec:

--- a/helm/flowforge/templates/network-policy.yaml
+++ b/helm/flowforge/templates/network-policy.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: flowforge-database-policy
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 spec:

--- a/helm/flowforge/templates/private-ca.yaml
+++ b/helm/flowforge/templates/private-ca.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certs"}}
-  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 data:

--- a/helm/flowforge/templates/service-account.yaml
+++ b/helm/flowforge/templates/service-account.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flowforge
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
   {{- if .Values.forge.cloudProvider }}
@@ -34,6 +35,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 rules:
@@ -60,13 +62,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}
-  namespace: {{ .Values.forge.projectNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: flowforge
-  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name:  {{ ((.Values.forge).clusterRole).name | default "create-pod" }}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: forge
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 spec:
@@ -17,6 +18,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flowforge-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
   annotations:
@@ -53,6 +55,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: flowforge-ingress-api-devices
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
## Description

This PR ensures that all resources are properly bound to the namespace and remmediates CKV_K8S_21 checkov issue.
Additionally, the helm-chart.yml file has been updated to set the HELM_NAMESPACE environment due to the [ongoing checkov problem](https://github.com/bridgecrewio/checkov/issues/3910).

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/250

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

