### PR TITLE
fix: Disable automounting of service account tokens

### DIFF
--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -68,6 +68,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.forge.broker.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- with .Values.forge.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_38=The service account token is required to schedule projects
 spec:
   replicas: {{ .Values.forge.replicas }}
   selector:
@@ -29,6 +31,7 @@ spec:
         {{- end  }}
     spec:
       serviceAccountName: flowforge
+      automountServiceAccountToken: true 
       securityContext:
         {{- toYaml .Values.forge.podSecurityContext | nindent 8 }}
       initContainers:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -38,6 +38,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/file-storage-configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.forge.fileStore.podSecurityContext | nindent 8 }}
       initContainers:


### PR DESCRIPTION
## Description

This pull request disables the automounting of service account tokens in the broker and file-storage deployments. This change improves security by preventing unauthorized access to service account tokens.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/258

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

