### PR TITLE
ci: Wait for container images build pipeline before running Helm chart release flow

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -9,6 +9,33 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for container images build
+        run: |
+          while :; do
+            result=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${{ github.repository }}/actions/runs | \
+              jq -r '.workflow_runs | map(select(.name == "Release container images")) | sort_by(.created_at) | reverse | .[0]')
+            status=$(echo "$result" | jq -r '.status')
+            conclusion=$(echo "$result" | jq -r '.conclusion')
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" == "success" ]]; then
+                echo "Release container images workflow completed successfully"
+                break
+              else
+                echo "Release container images workflow failed"
+                exit 1
+              fi
+            elif [[ "$status" == "in_progress" ]]; then
+              echo "Release container images workflow is still running"
+              sleep 60
+            else
+              echo "Release container images workflow returned unexpected status: $status"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

This pull request enhances the Helm chart release pipeline by integrating a step to wait for the completion of the container build workflow. This ensures that every released Helm chart points to an existing application container image. I opted for the API approach over [workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) for greater flexibility in building container images without automatically triggering the release of the Helm chart.

## Related Issue(s)

https://github.com/FlowFuse/admin/issues/301

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

