### PR TITLE
ci: Exclude advanced Helm chart validation on release

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -45,30 +45,18 @@ jobs:
           ct lint --config ./.github/configs/chart-testing.yaml
 
       - name: Create kind cluster
+        if: "${{!startsWith(github.event.pull_request.title, 'feat: Release')}}"
         uses: helm/kind-action@v1.8.0
 
       - name: Label cluster nodes
+        if: "${{!startsWith(github.event.pull_request.title, 'feat: Release')}}"
         run: |
           for node in $(kubectl get nodes -o name); do
             kubectl label --overwrite $node "role=management"
           done
 
-      - name: Wait for forge application public image
-        run: |
-          IMAGE="flowfuse/forge-k8s"
-          TAG=$(helm show chart ./helm/flowforge | awk -F': ' '/appVersion/ {print $2}')
-          ATTEMPTS=0
-          until docker manifest inspect $IMAGE:$TAG || [ $ATTEMPTS -eq 10 ]; do
-            ATTEMPTS=$((ATTEMPTS+1))
-            echo "Attempt $ATTEMPTS failed! Trying again in 30 seconds..."
-            sleep 30
-          done
-          if [ $ATTEMPTS -eq 10 ]; then
-            echo "Failed to inspect remote $IMAGE:$TAG after $ATTEMPTS attempts!"
-            exit 1
-          fi
-
       - name: Run chart-testing (install and upgrade)
+        if: "${{!startsWith(github.event.pull_request.title, 'feat: Release')}}"
         run: ct install --upgrade --config ./.github/configs/chart-testing.yaml
   
   validate:


### PR DESCRIPTION
## Description

This pull request adds a conditional to the helm chart lint pipeline which skips advanced helm chart validation on the release. This change fixes the chicken-egg problem which appears during the release process when container images and Helm chart versions are updated within the same pull request ([example](https://github.com/FlowFuse/helm/actions/runs/8644285534/job/23699100785)).

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

