### PR TITLE
fix: Temporarily skip CKV_K8S_35 for forge and file-server deployments

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- with .Values.forge.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Current approach is a temporary one 
 spec:
   replicas: {{ .Values.forge.replicas }}
   selector:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -23,6 +23,8 @@ metadata:
     {{- with .Values.forge.fileStore.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Current approach is a temporary one 
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

This pull request skips the CKV_K8S_35 check. 
The reason for skipping is that the current approach for injecting Kubernetes secret values into the application configuration is a temporary one and should be replaced with [a proper approach](https://github.com/FlowFuse/flowfuse/issues/3193) in the near future.

## Related Issue(s)

https://github.com/FlowFuse/helm/security/code-scanning/67

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

