### PR TITLE
fix: Skip CKV_K8S_10 and CKV_K8S_12 checks

### DIFF
--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -56,8 +56,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    checkov.io/skip1: CKV_K8S_11=We do not force default resources constraints
-    checkov.io/skip2: CKV_K8S_13=We do not force default resources constraints
+    checkov.io/skip1: CKV_K8S_10=We do not force default resources constraints
+    checkov.io/skip2: CKV_K8S_11=We do not force default resources constraints
+    checkov.io/skip3: CKV_K8S_12=We do not force default resources constraints
+    checkov.io/skip4: CKV_K8S_13=We do not force default resources constraints
 spec:
   selector:
     matchLabels:

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -9,10 +9,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    checkov.io/skip1: CKV_K8S_38=The service account token is required to schedule projects
-    checkov.io/skip2: CKV_K8S_35=Current approach is a temporary one
-    checkov.io/skip3: CKV_K8S_11=We do not force default resources constraints
+    checkov.io/skip1: CKV_K8S_10=We do not force default resources constraints
+    checkov.io/skip2: CKV_K8S_11=We do not force default resources constraints
+    checkov.io/skip3: CKV_K8S_12=We do not force default resources constraints
     checkov.io/skip4: CKV_K8S_13=We do not force default resources constraints
+    checkov.io/skip5: CKV_K8S_38=The service account token is required to schedule projects
+    checkov.io/skip6: CKV_K8S_35=Current approach is a temporary one
 spec:
   replicas: {{ .Values.forge.replicas }}
   selector:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -24,9 +24,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    checkov.io/skip1: CKV_K8S_35=Current approach is a temporary one
+    checkov.io/skip1: CKV_K8S_10=We do not force default resources constraints
     checkov.io/skip2: CKV_K8S_11=We do not force default resources constraints
-    checkov.io/skip3: CKV_K8S_13=We do not force default resources constraints 
+    checkov.io/skip3: CKV_K8S_12=We do not force default resources constraints
+    checkov.io/skip4: CKV_K8S_13=We do not force default resources constraints
+    checkov.io/skip5: CKV_K8S_35=Current approach is a temporary one
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

This pull request skips the CKV_K8S_10 and CKV_K8S_12 checks for the forge, file-server and broker deployments.
This is done because we do not want to apply default resource constraints that may not fit every environment. Additionally, it may slow down the application implementation process.
The cluster operator knows best what level of resources can be assigned to the application and should make such a decision independently. We are giving such a possibility via Helm chart values.
This is the follow-up of the [380](https://github.com/FlowFuse/helm/pull/380) 

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

