### PR TITLE
ci: Fix CHANGELOG.md path in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -25,7 +25,7 @@
     [
       '@semantic-release/changelog',
       {
-        "changelogFile": 'helm/flowforge/CHANGELOG.md'
+        "changelogFile": 'CHANGELOG.md'
       }
     ],
     [


### PR DESCRIPTION
## Description

This line is pointing to a wrong path. https://github.com/FlowFuse/helm/blob/main/.releaserc#L28
Changelog file doesn't exist inside of that directory but in the root, that's why CHANGELOG doesn't get updated


## Related Issue(s)

#346 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? --> CI related issue, not testing applies
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

