### PR TITLE
ci: revert "ci: Fix CHANGELOG.md path in .releaserc (#385)"

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -27,6 +27,13 @@
       {
         "changelogFile": "helm/flowforge/CHANGELOG.md"
       }
+    ],
+    [
+      "semantic-release-helm3",
+      {
+          "chartPath": "helm/flowforge",
+          "onlyUpdateVersion": true
+      }
     ]
   ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -25,7 +25,7 @@
     [
       '@semantic-release/changelog',
       {
-        "changelogFile": 'CHANGELOG.md'
+        "changelogFile": 'helm/flowforge/CHANGELOG.md'
       }
     ],
     [

--- a/.releaserc
+++ b/.releaserc
@@ -23,16 +23,9 @@
       }
     ],
     [
-      '@semantic-release/changelog',
+      "@semantic-release/changelog",
       {
-        "changelogFile": 'helm/flowforge/CHANGELOG.md'
-      }
-    ],
-    [
-      'semantic-release-helm3',
-      {
-          chartPath: 'helm/flowforge',
-          onlyUpdateVersion: true
+        "changelogFile": "helm/flowforge/CHANGELOG.md"
       }
     ]
   ]


### PR DESCRIPTION
## Description

This pull request reverts #385 .
As a result of above change
* CHANGELOG.md file was not part of the released Helm chart package 
* changelog was not generated properly for the Github Release

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/346

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

