### PR TITLE
fix: Add cnameTarget

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -170,6 +170,7 @@ Enables FlowForge Telemetry
  ### Instance Custom Hostnames
 
  - `forge.customHostname.enabled` activates the custom hostname feature (default `false`)
+ - `forge.customHostname.cnameTarget` the hostname of the ingress loadbalancer that custom hostnames must point to. Required (default not set)
  - `forge.customHostname.certManagerIssuer` name of CertManager ClusterIssuer to use to request HTTPS certificates for custom hostnames (default is not set)
  - `forge.customHostname.ingressClass` name of the IngressClass to use for exposing the custom hostname (default is not set)
  

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -65,6 +65,9 @@ data:
         {{- if .Values.forge.customHostname }}
         customHostname:
           enabled: {{ .Values.forge.customHostname.enabled }}
+        {{- if .Values.forge.customHostname.cnameTarget }}
+          cnameTarget: {{ .Values.forge.customHostname.cnameTarget }}
+        {{- end }}
         {{- if .Values.forge.customHostname.certManagerIssuer }}
           certManagerIssuer: {{ .Values.forge.customHostname.certManagerIssuer }}
         {{- end }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -65,9 +65,9 @@ data:
         {{- if .Values.forge.customHostname }}
         customHostname:
           enabled: {{ .Values.forge.customHostname.enabled }}
-        {{- if .Values.forge.customHostname.cnameTarget }}
-          cnameTarget: {{ .Values.forge.customHostname.cnameTarget }}
-        {{- end }}
+           {{ if default false .Values.forge.customHostname.enabled -}}
+          cnameTarget: {{ required "A value is required for .Values.forge.customHostname.cnameTarget" .Values.forge.customHostname.cnameTarget }}
+          {{- end -}}
         {{- if .Values.forge.customHostname.certManagerIssuer }}
           certManagerIssuer: {{ .Values.forge.customHostname.certManagerIssuer }}
         {{- end }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -781,6 +781,12 @@
                         },
                         "certManagerIssuer": {
                             "type": "string"
+                        },
+                        "ingressClass": {
+                            "type": "string"
+                        },
+                        "cnameTarget": {
+                            "type": "string"
                         }
                     }
                 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
I missed a bit of config from the helm chart.

(if you know how to make forge.customHostname.cnameTarget required if forge.customerHostname.enabled = true that would be greate)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

