### PR TITLE
chore: Add extra tags to the FF NR stack containers

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-2.2.3,value=${{ github.event.inputs.version }}
+            type=raw,value=latest-2.2.3
           flavor: |
             latest=false
           images: |
@@ -162,6 +163,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-3.1.x,value=${{ github.event.inputs.version }}
+            type=raw,value=latest-3.1.x
           flavor: |
             latest=false
           images: |
@@ -198,6 +200,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-4.0.x,value=${{ github.event.inputs.version }}
+            type=raw,value=latest-4.0.x
           flavor: |
             latest=false
           images: |


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This adds `latest-{nr version}` tags to each build.

This allows us to update the default stack created on install to track something other than 3.0.x

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

