### PR TITLE
Update Dockerfile-4.0 to base on 4.0 image

### DIFF
--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,4 +1,4 @@
-FROM nodered/node-red-dev:v4.0.0-beta.4
+FROM nodered/node-red:4.0.0-20
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
Move from beta container to the full 4.0 release container. Defaulting to Node 20.