### PR TITLE
fix: indentation within custom hostname configuration

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -65,7 +65,7 @@ data:
         {{- if .Values.forge.customHostname }}
         customHostname:
           enabled: {{ .Values.forge.customHostname.enabled }}
-           {{ if default false .Values.forge.customHostname.enabled -}}
+          {{ if default false .Values.forge.customHostname.enabled -}}
           cnameTarget: {{ required "A value is required for .Values.forge.customHostname.cnameTarget" .Values.forge.customHostname.cnameTarget }}
           {{- end -}}
         {{- if .Values.forge.customHostname.certManagerIssuer }}


### PR DESCRIPTION
## Description

This pull request fixex indentation within config map object related to custom hostnames feature.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

