### PR TITLE
ci: check more than 100 workflow runs for status

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo $GITHUB_TOKEN | gh auth login --with-token
+          gh auth login --with-token
 
       - name: Wait for container images build
         run: |

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -2,6 +2,9 @@ name: Release Helm Chart
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   release:
@@ -46,27 +49,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
+        if: false
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        if: true
+        if: false
         uses: azure/setup-helm@v4
         with:
           token: ${{ github.token }}
 
       - name: Add dependencies
-        if: true
+        if: false
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Configure git
+        if: false
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Semantic Release
+        if: false
         id: semantic-release
         uses: cycjimmy/semantic-release-action@v4
         env:
@@ -78,6 +84,7 @@ jobs:
             semantic-release-helm3@2.9.3
 
       - name: Run chart-releaser
+        if: false
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -2,12 +2,6 @@ name: Release Helm Chart
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   release:
@@ -46,24 +40,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Helm
-        if: false
         uses: azure/setup-helm@v4
         with:
           token: ${{ github.token }}
 
       - name: Add dependencies
-        if: false
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Configure git
-        if: false
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Semantic Release
-        if: false
         id: semantic-release
         uses: cycjimmy/semantic-release-action@v4
         env:
@@ -75,7 +65,6 @@ jobs:
             semantic-release-helm3@2.9.3
 
       - name: Run chart-releaser
-        if: false
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -15,11 +15,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gh
-
       - name: Authenticate GitHub CLI
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   release:

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -15,12 +15,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Authenticate GitHub CLI
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh auth login --with-token
-
       - name: Wait for container images build
         run: |
           while :; do

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -15,6 +15,11 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Wait for container images build
         run: |
           while :; do
@@ -39,12 +44,6 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout
-        if: false
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install Helm
         if: false

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -9,12 +9,21 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Authenticate GitHub CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo $GITHUB_TOKEN | gh auth login --with-token
+
       - name: Wait for container images build
         run: |
           while :; do
-            result=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              https://api.github.com/repos/${{ github.repository }}/actions/runs | \
-              jq -r '.workflow_runs | map(select(.name == "Release container images")) | sort_by(.created_at) | reverse | .[0]')
+            result=$(gh api repos/:owner/:repo/actions/workflows | jq -r '.workflows[] | select(.name=="Release container images") | .id' | xargs -I {} gh api repos/:owner/:repo/actions/workflows/{}/runs --jq '.workflow_runs | max_by(.run_number)')
             status=$(echo "$result" | jq -r '.status')
             conclusion=$(echo "$result" | jq -r '.conclusion')
             if [[ "$status" == "completed" ]]; then


### PR DESCRIPTION
## Description

This pull request replaces `curl` with `gh` while gathering status of latest "Release container images" workflow run. Replacement of the commands is a quick solution for paginating api results.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

