### PR TITLE
fix: avoid parallel images update

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -130,7 +130,7 @@ jobs:
   update-production-image:
     if: github.ref_name == 'main'
     name: Update production image
-    needs: upload-production-image
+    needs: [upload-production-image, update-stage-image]
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -132,7 +132,7 @@ jobs:
   update-production-image:
     if: github.ref_name == 'main'
     name: Update production image
-    needs: upload-production-image
+    needs: [upload-production-image, update-stage-image]
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Description

This pull request applies temporary fix to avoid concurrent push into the same branch by two separate jobs.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

