### PR TITLE
ci: Update container images in single git push

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -68,47 +68,6 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
-  update-stage-image:
-    if: github.ref_name == 'main'
-    name: Update staging image
-    needs: upload-stage-image
-    runs-on: ubuntu-latest
-    environment: stage
-    steps:
-      - name: Configure AWS credentials
-        id: aws-config
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
-      - name: Generate a token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_APP_KEY }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: 'FlowFuse/CloudProject'
-          ref: 'main'
-          token: ${{ steps.generate_token.outputs.token }}
-      - name: Install yq
-        uses: alexellis/arkade-get@master
-        with:
-          yq: v4.42.1
-      - name: Update staging deployment
-        run: |
-          image_value="${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-stage-image.outputs.image }}"
-          yq e ".forge.fileStore.image = \"$image_value\"" -i ./staging/flowfuse-values.yaml
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add ./staging/flowfuse-values.yaml
-          git commit -m "Update file-server staging image to ${{ needs.upload-stage-image.outputs.image }}"
-          git push origin main
-
   upload-production-image:
     if: github.ref_name == 'main'
     name: Upload image to production registry
@@ -127,21 +86,12 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
-  update-production-image:
+  update-images:
     if: github.ref_name == 'main'
-    name: Update production image
-    needs: [upload-production-image, update-stage-image]
+    name: Update images
+    needs: [upload-production-image, upload-stage-image]
     runs-on: ubuntu-latest
-    environment: production
     steps:
-      - name: Configure AWS credentials
-        id: aws-config
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -158,14 +108,18 @@ jobs:
         uses: alexellis/arkade-get@master
         with:
           yq: v4.42.1
-      - name: Update staging deployment
+      - name: Update images
         run: |
-          image_value="${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-production-image.outputs.image }}"
-          yq e ".forge.fileStore.image = \"$image_value\"" -i ./production/flowfuse-values.yaml
+          production_image_value="${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-production-image.outputs.image }}"
+          staging_image_value="${{ secrets.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-stage-image.outputs.image }}"
+          yq e ".forge.fileStore.image = \"$production_image_value\"" -i ./production/flowfuse-values.yaml
+          yq e ".forge.fileStore.image = \"$staging_image_value\"" -i ./staging/flowfuse-values.yaml
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./staging/flowfuse-values.yaml
+          git commit -m "Update file-server staging image to ${{ needs.upload-stage-image.outputs.image }}"
           git add ./production/flowfuse-values.yaml
-          git commit -m "Update file-server staging image ${{ needs.upload-production-image.outputs.image }}"
+          git commit -m "Update file-server production image to ${{ needs.upload-production-image.outputs.image }}"
           git push origin main
 
   deploy-stage:

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -69,48 +69,6 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
-  update-stage-image:
-    if: github.ref_name == 'main'
-    name: Update staging image
-    needs: upload-stage-image
-    runs-on: ubuntu-latest
-    environment: stage
-    steps:
-      - name: Configure AWS credentials
-        id: aws-config
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
-      - name: Generate a token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_APP_KEY }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: 'FlowFuse/CloudProject'
-          ref: 'main'
-          token: ${{ steps.generate_token.outputs.token }}
-      - name: Install yq
-        uses: alexellis/arkade-get@master
-        with:
-          yq: v4.42.1
-      - name: Update staging deployment
-        run: |
-          image_value="${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-stage-image.outputs.image }}"
-          yq e ".forge.image = \"$image_value\"" -i ./staging/flowfuse-values.yaml
-          git config --global user.name "GitHub Actions Bot"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add ./staging/flowfuse-values.yaml
-          git commit -m "Update forge staging image to ${{ needs.upload-stage-image.outputs.image }}"
-          git push origin main
-
-
   upload-production-image:
     if: github.ref_name == 'main'
     name: Upload image to production registry
@@ -129,21 +87,12 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
       eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
 
-  update-production-image:
+  update-images:
     if: github.ref_name == 'main'
-    name: Update production image
-    needs: [upload-production-image, update-stage-image]
+    name: Update images
+    needs: [upload-production-image, upload-stage-image]
     runs-on: ubuntu-latest
-    environment: production
     steps:
-      - name: Configure AWS credentials
-        id: aws-config
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -160,12 +109,16 @@ jobs:
         uses: alexellis/arkade-get@master
         with:
           yq: v4.42.1
-      - name: Update production deployment
+      - name: Update images
         run: |
-          image_value="${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-production-image.outputs.image }}"
-          yq e ".forge.image = \"$image_value\"" -i ./production/flowfuse-values.yaml
+          production_image_value="${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-production-image.outputs.image }}"
+          staging_image_value="${{ secrets.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-stage-image.outputs.image }}"
+          yq e ".forge.image = \"$production_image_value\"" -i ./production/flowfuse-values.yaml
+          yq e ".forge.image = \"$staging_image_value\"" -i ./staging/flowfuse-values.yaml
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./staging/flowfuse-values.yaml
+          git commit -m "Update forge staging image to ${{ needs.upload-stage-image.outputs.image }}"
           git add ./production/flowfuse-values.yaml
           git commit -m "Update forge production image to ${{ needs.upload-production-image.outputs.image }}"
           git push origin main


### PR DESCRIPTION
## Description

This pull request updates fileserver and forge container deployment approach. It changes the way how updates to `flowfuse-values.yaml` files are pushed to the CloudProject repo. Instead of multiple pushes, single one is performed with all required changes.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/420

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

