### PR TITLE
ci: Generate main changelog after Helm chart release

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -9,9 +9,17 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
 
       - name: Wait for container images build
@@ -72,3 +80,29 @@ jobs:
           charts_dir: helm
           config: .github/configs/cr.yaml
           skip_existing: true
+
+      - name: Update main changelog
+        if: steps.semantic-release.outputs.new_release_published == 'true'
+        run: |
+          releases=$(gh release list --limit 2 --json name)
+          latest_release_tag=$(echo "$releases" | jq -r '.[0].name')
+          previous_release_tag=$(echo "$releases" | jq -r '.[1].name')
+          clean_latest_version=$(echo $latest_release_tag | sed -E 's/v//g')
+          echo "#### ${clean_latest_version}: Release" >> CHANGELOG.new
+          echo >> CHANGELOG.new
+          for logEntry in $(git log --first-parent --merges --abbrev-commit --pretty=oneline $previous_release_tag..$latest_release_tag| sed -E 's/^.*#//g;s/ from.*//g;/Merge branch/d;s/[^0-9]*//g')
+          do
+            echo " - "$(gh pr view $logEntry --json title,number,author -t "{{.title}} (#{{.number}}) @{{.author.login}}") >> CHANGELOG.new
+          done
+          echo >> CHANGELOG.new
+          if [ -e CHANGELOG.md ]
+          then
+            cat CHANGELOG.md >> CHANGELOG.new
+          fi
+          mv CHANGELOG.new CHANGELOG.md
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG for $clean_latest_version [no ci]"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pull request adds a step into "Release Helm Chart" workflow which ensures, that main CHANGELOG.md file will be updated after the release.
The script copies the approach from `admin` repo. However, since it compares last two releases, minor adjustments were made.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/346

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

