### PR TITLE
ci: Build amd64 images only for FFC

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -35,6 +35,7 @@ jobs:
       package_dependencies: |
         @flowfuse/file-server
       build_context: 'file-server'
+      build_platforms: '["linux/amd64"]'
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
@@ -47,6 +48,8 @@ jobs:
     uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.10.0
     with:
       image_name: 'file-server'
+      architecture_suffixes: |
+        -linux-amd64
     secrets:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -36,6 +36,7 @@ jobs:
         @flowfuse/flowfuse
         @flowfuse/driver-kubernetes
       build_context: 'flowforge-container'
+      build_platforms: '["linux/amd64"]'
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
@@ -48,6 +49,8 @@ jobs:
     uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.10.0
     with:
       image_name: 'forge-k8s'
+      architecture_suffixes: |
+        -linux-amd64
     secrets:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This pull request changes how images for FFC are built. Instead of multi-architecture image, only amd64 version is creatged.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/416

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

