### PR TITLE
fix: Add `VERSIONING.md` to helm ignored files

### DIFF
--- a/helm/flowforge/.helmignore
+++ b/helm/flowforge/.helmignore
@@ -1,2 +1,3 @@
 .helmignore
 tests/
+VERSIONING.md


### PR DESCRIPTION
## Description

This pull request forces helm chart patch release.
Additionally, it adds `VERIONING.md` file to the list of helm ignored ones. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

