### PR TITLE
Allow SES SourceARN to be set

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -80,6 +80,7 @@ To use STMP to send email
  To use AWS SES to send email
 
  - `forge.email.ses.region` the AWS region the SES service is enabled
+ - `forge.email.ses.sourceArn` the AWS ARN for the identity to send email as (optional, default not set)
 
  ### MQTT Broker
 

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -108,6 +108,9 @@ data:
     {{- if .Values.forge.email.ses }}
       ses:
         region: {{ .Values.forge.email.ses.region }}
+        {{- if .Values.forge.email.ses.sourceArn }}
+        sourceArn: {{ .Values.forge.email.ses.sourceArn }}
+        {{- end }}
     {{- end }}
     {{- else }}
     email:


### PR DESCRIPTION
part of FlowFuse/flowfuse#4173

## Description

<!-- Describe your changes in detail -->
Allows AWS SES `sourceArn` to be configured when using a shared SES instance.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#4173

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

