### PR TITLE
feat: Add possibility to configure Prometheus endpoint for FileStore app

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -166,6 +166,7 @@ Enables FlowForge Telemetry
 - `forge.fileStore.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 - `forge.fileStore.labels` allows to add custom labels to the file-server related objects (e.g. deployment, services, etc.) (default `{}`)
 - `forge.fileStore.podLabels` allows to add custom labels to the file-server pod (default `{}`)
+- `forge.fileStore.telemetry.backend.prometheus.enabled` enables the `/metrics` endpoint on the fileStore app for scraping by Prometheus
 
 ### Persistent Storage
 

--- a/helm/flowforge/templates/file-storage-configmap.yaml
+++ b/helm/flowforge/templates/file-storage-configmap.yaml
@@ -43,7 +43,7 @@ data:
     telemetry:
       backend:
         prometheus:
-          enabled: {{ .Values.forge.fileStore.telemetry.backend.prometheus.enabled }}
+          enabled: {{ (((.Values.forge.fileStore.telemetry).backend).prometheus).enabled | default false}}
     logging:
       level: info
       http: info

--- a/helm/flowforge/templates/file-storage-configmap.yaml
+++ b/helm/flowforge/templates/file-storage-configmap.yaml
@@ -40,6 +40,10 @@ data:
         {{- end }}
       {{- end }}
     {{- end }}
+    telemetry:
+      backend:
+        prometheus:
+          enabled: {{ .Values.forge.fileStore.telemetry.backend.prometheus.enabled }}
     logging:
       level: info
       http: info

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -43,6 +43,11 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/file-storage-configmap.yaml") . | sha256sum }}
+        {{- if .Values.forge.fileStore.telemetry.backend.prometheus.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3000"
+        prometheus.io/path: "/metrics"
+        {{- end  }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -43,7 +43,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/file-storage-configmap.yaml") . | sha256sum }}
-        {{- if .Values.forge.fileStore.telemetry.backend.prometheus.enabled }}
+        {{- if default false (((.Values.forge.fileStore.telemetry).backend).prometheus).enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "3000"
         prometheus.io/path: "/metrics"

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -586,7 +586,7 @@
                         "image": {
                             "type": "string"
                         },
-                        "telemetry" {
+                        "telemetry": {
                             "type": "object",
                             "backend": {
                                 "type": "object",

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -585,6 +585,22 @@
                         },
                         "image": {
                             "type": "string"
+                        },
+                        "telemetry" {
+                            "type": "object",
+                            "backend": {
+                                "type": "object",
+                                "properties": {
+                                    "prometheus": {
+                                        "type": "object",
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     "required": [

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -70,6 +70,10 @@ forge:
       readOnlyRootFilesystem: true
     labels: {}
     podLabels: {}
+    telemetry:
+      backend:
+        prometheus:
+          enabled: false
 
   support:
     enabled: false


### PR DESCRIPTION
## Description

This pull requests adds the possibility to enable `/metrics` endpoint with FileStore app metrics. Metrics can be consumed by a Prometheus instance.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

