### PR TITLE
fix: Set prometheus scrape port for `flowforge-file` to `3001`

### DIFF
--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -45,7 +45,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/file-storage-configmap.yaml") . | sha256sum }}
         {{- if default false (((.Values.forge.fileStore.telemetry).backend).prometheus).enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "3000"
+        prometheus.io/port: "3001"
         prometheus.io/path: "/metrics"
         {{- end  }}
     spec:


### PR DESCRIPTION
## Description

This pull request sets proper value for `prometheus.io/port` annotation within `flowforge-file` deployment.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

