### PR TITLE
fix: Ensure default private ca cert cm name

### DIFF
--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -54,7 +54,7 @@ data:
         cloudProvider: {{ .Values.forge.cloudProvider }}
         {{- end }}
         {{- if .Values.forge.privateCA }}
-        privateCA: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }}
+        privateCA: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certs" }}
         {{- end }}
         {{- if .Values.ingress.certManagerIssuer }}
         certManagerIssuer: {{ .Values.ingress.certManagerIssuer }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -54,7 +54,7 @@ data:
         cloudProvider: {{ .Values.forge.cloudProvider }}
         {{- end }}
         {{- if .Values.forge.privateCA }}
-        privateCA: {{ .Values.forge.privateCA.configMapName }}
+        privateCA: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }}
         {{- end }}
         {{- if .Values.ingress.certManagerIssuer }}
         certManagerIssuer: {{ .Values.ingress.certManagerIssuer }}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -176,7 +176,7 @@ spec:
       {{- if .Values.forge.privateCA }}
       - name: cacert
         configMap:
-          name: {{ .Values.forge.privateCA.configMapName }}
+          name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }}
       {{- end }}
       {{- if .Values.forge.managementSelector }}
       nodeSelector:

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -176,7 +176,7 @@ spec:
       {{- if .Values.forge.privateCA }}
       - name: cacert
         configMap:
-          name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }}
+          name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certs" }}
       {{- end }}
       {{- if .Values.forge.managementSelector }}
       nodeSelector:

--- a/helm/flowforge/templates/private-ca.yaml
+++ b/helm/flowforge/templates/private-ca.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certts" }} 
+  name: {{ .Values.forge.privateCA.configMapName | default "ff-ca-certs" }} 
   namespace: {{ .Values.forge.projectNamespace | default "flowforge" }}
   labels:
   {{- include "forge.labels" . | nindent 4 }}


### PR DESCRIPTION
fixes #450

## Description

<!-- Describe your changes in detail -->
The deployment template was missing the default value for the private ca cert configmap

As was the flowforge.yml configmap.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#450

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

