### PR TITLE
ci: Revert `merge_multiarch_images` workflow version bump

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -45,7 +45,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'file-server'
       architecture_suffixes: |

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -46,7 +46,7 @@ jobs:
   build-multi-architecture:
     name: Build multi-architecture container image
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'forge-k8s'
       architecture_suffixes: |

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -46,7 +46,7 @@ jobs:
   build-302-multi-architecture:
     name: Build multi-architecture container image
     needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.0.2-'
@@ -110,7 +110,7 @@ jobs:
   build-223-multi-architecture:
     name: Build multi-architecture container image
     needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '2.2.3-'
@@ -174,7 +174,7 @@ jobs:
   build-310-multi-architecture:
     name: Build multi-architecture container image
     needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '3.1.x-'
@@ -238,7 +238,7 @@ jobs:
   build-40-multi-architecture:
     name: Build multi-architecture container image
     needs: build-40
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
     with:
       image_name: 'node-red'
       image_tag_prefix: '4.0.x-'


### PR DESCRIPTION
## Description

This pull request reverts `merge_multiarch_images` reusable workflow bump back to `v0.14.0`. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

