### PR TITLE
ci: Bump containers reusable workflow version to `v0.29.0`

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -29,42 +29,31 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'file-server'
       package_dependencies: |
         @flowfuse/file-server
       build_context: 'file-server'
-      build_platforms: '["linux/amd64"]'
+      build_platform: "linux/amd64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'file-server'
-      architecture_suffixes: |
-        -linux-amd64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-
   upload-stage-image:
     if: github.ref_name == 'main'
     name: Upload image to staging registry
-    needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'file-server'
       deployment_name: 'flowforge-file'
       container_name: 'file-storage'
       deploy: false
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -74,15 +63,15 @@ jobs:
   upload-production-image:
     if: github.ref_name == 'main'
     name: Upload image to production registry
-    needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'file-server'
       deployment_name: 'flowforge-file'
       container_name: 'file-storage'
       deploy: false
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -129,14 +118,14 @@ jobs:
     # if: github.ref_name == 'main'
     if: false
     name: Deploy to staging environment
-    needs: build-multi-architecture
+    needs: build
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: stage
       service_name: 'file-server'
       deployment_name: 'flowforge-file'
       container_name: 'file-storage'
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -147,14 +136,14 @@ jobs:
     # if: github.ref_name == 'main'
     if: false
     name: Deploy to production environment
-    needs: [build-multi-architecture, deploy-stage]
+    needs: [build, deploy-stage]
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: production
       service_name: 'file-server'
       deployment_name: 'flowforge-file'
       container_name: 'file-storage'
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@feat-refactor-image-build
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -60,7 +60,7 @@ jobs:
     name: Upload image to staging registry
     needs: build
     # needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -80,7 +80,7 @@ jobs:
     name: Upload image to production registry
     # needs: build-multi-architecture
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'forge-k8s'
@@ -136,7 +136,7 @@ jobs:
     if: false
     name: Deploy to staging environment
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'forge-k8s'
@@ -154,7 +154,7 @@ jobs:
     if: false
     name: Deploy to production environment
     needs: [build, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'forge-k8s'

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -36,7 +36,6 @@ jobs:
         @flowfuse/flowfuse
         @flowfuse/driver-kubernetes
       build_context: 'flowforge-container'
-      # build_platforms: '["linux/amd64"]'
       build_platform: "linux/amd64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
@@ -44,19 +43,8 @@ jobs:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # build-multi-architecture:
-  #   name: Build multi-architecture container image
-  #   needs: build
-  #   uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-  #   with:
-  #     image_name: 'forge-k8s'
-  #     architecture_suffixes: |
-  #       -linux-amd64
-  #   secrets:
-  #     temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-
   upload-stage-image:
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     name: Upload image to staging registry
     needs: build
     # needs: build-multi-architecture

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -29,35 +29,37 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@feat-refactor-image-build
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
         @flowfuse/flowfuse
         @flowfuse/driver-kubernetes
       build_context: 'flowforge-container'
-      build_platforms: '["linux/amd64"]'
+      # build_platforms: '["linux/amd64"]'
+      build_platform: "linux/amd64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'forge-k8s'
-      architecture_suffixes: |
-        -linux-amd64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+  # build-multi-architecture:
+  #   name: Build multi-architecture container image
+  #   needs: build
+  #   uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
+  #   with:
+  #     image_name: 'forge-k8s'
+  #     architecture_suffixes: |
+  #       -linux-amd64
+  #   secrets:
+  #     temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-stage-image:
-    if: github.ref_name == 'main'
+    # if: github.ref_name == 'main'
     name: Upload image to staging registry
-    needs: build-multi-architecture
+    needs: build
+    # needs: build-multi-architecture
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: stage
@@ -65,7 +67,8 @@ jobs:
       deployment_name: flowforge
       container_name: forge
       deploy: false
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      # image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -75,7 +78,8 @@ jobs:
   upload-production-image:
     if: github.ref_name == 'main'
     name: Upload image to production registry
-    needs: build-multi-architecture
+    # needs: build-multi-architecture
+    needs: build
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: production

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -87,7 +87,8 @@ jobs:
       deployment_name: flowforge
       container_name: forge
       deploy: false
-      image: ${{ needs.build-multi-architecture.outputs.image }}
+      # image: ${{ needs.build-multi-architecture.outputs.image }}
+      image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -134,7 +135,7 @@ jobs:
     # if: github.ref_name == 'main'
     if: false
     name: Deploy to staging environment
-    needs: build-multi-architecture
+    needs: build
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: stage
@@ -152,7 +153,7 @@ jobs:
     # if: github.ref_name == 'main'
     if: false
     name: Deploy to production environment
-    needs: [build-multi-architecture, deploy-stage]
+    needs: [build, deploy-stage]
     uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
     with:
       environment: production

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-302:
     name: Build 3.0.2 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
@@ -37,35 +37,25 @@ jobs:
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
-      build_platforms: '["linux/arm64"]'
+      build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-  build-302-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'node-red'
-      image_tag_prefix: '3.0.2-'
-      architecture_suffixes: |
-        -linux-arm64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
+
   upload-302-stage:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
-    needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-302
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-302-multi-architecture.outputs.image }}
+      image: ${{ needs.build-302.outputs.image }}
       image_tag_prefix: '3.0.2-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -75,15 +65,15 @@ jobs:
   upload-302-prod:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
-    needs: build-302-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-302
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-302-multi-architecture.outputs.image }}
+      image: ${{ needs.build-302.outputs.image }}
       image_tag_prefix: '3.0.2-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -93,7 +83,7 @@ jobs:
 
   build-223:
     name: Build 2.2.3 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-2.2.x
@@ -101,35 +91,24 @@ jobs:
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
-      build_platforms: '["linux/arm64"]'
+      build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-  build-223-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'node-red'
-      image_tag_prefix: '2.2.3-'
-      architecture_suffixes: |
-        -linux-arm64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-223-stage:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
-    needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-223
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-223-multi-architecture.outputs.image }}
+      image: ${{ needs.build-223.outputs.image }}
       image_tag_prefix: '2.2.3-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -139,15 +118,15 @@ jobs:
   upload-223-prod:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
-    needs: build-223-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-223
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-223-multi-architecture.outputs.image }}
+      image: ${{ needs.build-223.outputs.image }}
       image_tag_prefix: '2.2.3-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -157,7 +136,7 @@ jobs:
 
   build-310:
     name: Build 3.1.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-3.1
@@ -165,35 +144,24 @@ jobs:
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
-      build_platforms: '["linux/arm64"]'
+      build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-  build-310-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'node-red'
-      image_tag_prefix: '3.1.x-'
-      architecture_suffixes: |
-        -linux-arm64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-310-stage:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
-    needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-310
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-310-multi-architecture.outputs.image }}
+      image: ${{ needs.build-310.outputs.image }}
       image_tag_prefix: '3.1.x-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -203,15 +171,15 @@ jobs:
   upload-310-prod:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
-    needs: build-310-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-310
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-310-multi-architecture.outputs.image }}
+      image: ${{ needs.build-310.outputs.image }}
       image_tag_prefix: '3.1.x-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +189,7 @@ jobs:
 
   build-40:
     name: Build 4.0.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.28.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.29.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-4.0
@@ -229,35 +197,24 @@ jobs:
       package_dependencies: |
         @flowforge/nr-project-nodes
       build_context: 'node-red-container'
-      build_platforms: '["linux/arm64"]'
+      build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
       scan_image: true
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-  build-40-multi-architecture:
-    name: Build multi-architecture container image
-    needs: build-40
-    uses: flowfuse/github-actions-workflows/.github/workflows/merge_multiarch_images.yml@v0.14.0
-    with:
-      image_name: 'node-red'
-      image_tag_prefix: '4.0.x-'
-      architecture_suffixes: |
-        -linux-arm64
-    secrets:
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
   upload-40-stage:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
-    needs: build-40-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-40
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: stage
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-40-multi-architecture.outputs.image }}
+      image: ${{ needs.build-40.outputs.image }}
       image_tag_prefix: '4.0.x-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -267,15 +224,15 @@ jobs:
   upload-40-prod:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
-    needs: build-40-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.28.0
+    needs: build-40
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.29.0
     with:
       environment: production
       service_name: 'node-red'
       deployment_name: 'node-red'
       container_name: 'node-red'
       deploy: false
-      image: ${{ needs.build-40-multi-architecture.outputs.image }}
+      image: ${{ needs.build-40.outputs.image }}
       image_tag_prefix: '4.0.x-'
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

This pull request updates the reusable workflows to the `v0.29.0` version.
In this particular version, the `build_container_image` workflow has been refactored. Starting from `v0.29.0` workflow builds a single architecture using the platform defined via `build_platform` input.
Additionally, the step responsible for building a multiarchitecture image has been removed, cutting down the time needed, to build the image.

## Related Issue(s)

closes https://github.com/FlowFuse/helm/issues/456

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

