### PR TITLE
feat: add possibility to configure tolerations

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -50,6 +50,7 @@ For other values please refer to the documentation below.
  - `forge.labels` allows to add custom labels to the core application related objects (e.g. deployment, services, etc.) (default `{}`)
  - `forge.podLabels` allows to add custom labels to the core application pod (default `{}`)
  - `forge.replicas` allows the number of instances of the FlowFuse App to be set. Scaling only supported with ingress-nginx controller (default `1`)
+ - `forge.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the core application deployment (default `[]`)
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
@@ -100,6 +101,7 @@ To use STMP to send email
   - `forge.broker.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the broker pod (check [here](#liveness-readiness-and-startup-probes) for more details)
   - `forge.broker.labels` allows to add custom labels to the broker related objects (e.g. deployment, services, etc.) (default `{}`)
   - `forge.broker.podLabels` allows to add custom labels to the broker pod (default `{}`)
+  - `forge.broker.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the broker deployment (default `[]`)
   - `forge.broker.ingress.annotations` broker ingress annotations (default is `{}`)
 
 `forge.broker.ingress.annotations` values can contain the following tokens that will be replaced as follows:
@@ -167,6 +169,7 @@ Enables FlowForge Telemetry
 - `forge.fileStore.startupProbe` block with [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) configuration for the flowforge-file pod (check [here](#liveness-readiness-and-startup-probes) for more details)
 - `forge.fileStore.labels` allows to add custom labels to the file-server related objects (e.g. deployment, services, etc.) (default `{}`)
 - `forge.fileStore.podLabels` allows to add custom labels to the file-server pod (default `{}`)
+- `forge.fileStore.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the file-server deployment (default `[]`)
 - `forge.fileStore.telemetry.backend.prometheus.enabled` enables the `/metrics` endpoint on the fileStore app for scraping by Prometheus
 
 ### Persistent Storage

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -92,6 +92,10 @@ spec:
         {{- if .Values.forge.broker.resources }}
         resources: {{- toYaml .Values.forge.broker.resources | nindent 12 }}
         {{- end }}
+      {{- if .Values.forge.broker.tolerations}}
+      tolerations:
+      {{ toYaml .Values.forge.broker.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Values.forge.registrySecrets }}
       imagePullSecrets:
       {{- range .Values.forge.registrySecrets }}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -161,6 +161,10 @@ spec:
         resources: {{- toYaml .Values.forge.resources | nindent 12 }}
         {{- end }}
         securityContext: {{- toYaml .Values.forge.containerSecurityContext | nindent 10 }}
+      {{- if .Values.forge.tolerations}}
+      tolerations:
+      {{ toYaml .Values.forge.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Values.forge.registrySecrets }}
       imagePullSecrets:
       {{- range .Values.forge.registrySecrets }}

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -131,6 +131,10 @@ spec:
         {{- if .Values.forge.fileStore.resources }}
         resources: {{- toYaml .Values.forge.fileStore.resources | nindent 12 }}
         {{- end }}
+      {{- if .Values.forge.fileStore.tolerations}}
+      tolerations:
+      {{ toYaml .Values.forge.fileStore.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Values.forge.registrySecrets }}
       imagePullSecrets:
       {{- range .Values.forge.registrySecrets }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -346,6 +346,9 @@
                         "labels": {
                             "type": "object"
                         },
+                        "tolerations": {
+                            "type": "array"
+                        },
                         "ingress": {
                             "type": "object",
                             "properties": {
@@ -586,6 +589,9 @@
                         "labels": {
                             "type": "object"
                         },
+                        "tolerations": {
+                            "type": "array"
+                        },
                         "image": {
                             "type": "string"
                         },
@@ -815,6 +821,9 @@
                 },
                 "labels": {
                     "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
                 },
                 "logPassthrough": {
                     "type": "boolean"

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -43,6 +43,7 @@ forge:
       readOnlyRootFilesystem: true
     labels: {}
     podLabels: {}
+    tolerations: []
     ingress.annotations: {}
 
   persistentStorage:
@@ -70,6 +71,7 @@ forge:
       readOnlyRootFilesystem: true
     labels: {}
     podLabels: {}
+    tolerations: []
     telemetry:
       backend:
         prometheus:
@@ -120,6 +122,8 @@ forge:
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 3
+  
+  tolerations: []
 
   logPassthrough: false
   customHostname:


### PR DESCRIPTION
## Description

This pull requests add a possibility to configure tolerations for all deployments created by the Helm chart.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/462

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

