### PR TITLE
ci: temporarily disable container scan with Trivy

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -37,7 +37,7 @@ jobs:
       build_context: 'file-server'
       build_platform: "linux/amd64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -26,6 +26,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+
 jobs:
   build:
     name: Build single-architecture container images

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -39,7 +39,7 @@ jobs:
       build_context: 'flowforge-container'
       build_platform: "linux/amd64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@fix-trivy-custom-vuln-db
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.30.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.30.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@fix-trivy-custom-vuln-db
     with:
       image_name: 'forge-k8s'
       package_dependencies: |

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -39,7 +39,7 @@ jobs:
       build_context: 'node-red-container'
       build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
       build_context: 'node-red-container'
       build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -146,7 +146,7 @@ jobs:
       build_context: 'node-red-container'
       build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -199,7 +199,7 @@ jobs:
       build_context: 'node-red-container'
       build_platform: "linux/arm64"
       npm_registry_url: ${{ vars.PUBLIC_NPM_REGISTRY_URL }}
-      scan_image: true
+      scan_image: false
     secrets:
       npm_registry_auth_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pull request temporarily disable container images scanning with Trivy due to the [known issue](https://github.com/aquasecurity/trivy-action/issues/389).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

