### PR TITLE
Bump Node-RED container to 4.0.4

### DIFF
--- a/node-red-container/Dockerfile-4.0
+++ b/node-red-container/Dockerfile-4.0
@@ -1,4 +1,4 @@
-FROM nodered/node-red:4.0.3-20
+FROM nodered/node-red:4.0.4-20
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
At the time of raising, the Node-RED docker builds are still running: https://github.com/node-red/node-red-docker/actions/runs/11252956584