### PR TITLE
feat: Add possibility to apply `priorityClassName` to all deployments

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -51,6 +51,7 @@ For other values please refer to the documentation below.
  - `forge.podLabels` allows to add custom labels to the core application pod (default `{}`)
  - `forge.replicas` allows the number of instances of the FlowFuse App to be set. Scaling only supported with ingress-nginx controller (default `1`)
  - `forge.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the core application deployment (default `[]`)
+ - `forge.priorityClassName` allows to set [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) for all deployments created by this Helm chart (default not set)
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -28,6 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.forge.priorityClassName }}
+      priorityClassName: "{{ .Values.forge.priorityClassName}}"
+      {{- end }}
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.forge.broker.podSecurityContext | nindent 8 }}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
         prometheus.io/path: "/metrics"
         {{- end  }}
     spec:
+      {{- if .Values.forge.priorityClassName }}
+      priorityClassName: "{{ .Values.forge.priorityClassName}}"
+      {{- end }}
       serviceAccountName: flowforge
       automountServiceAccountToken: true 
       securityContext:

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -49,6 +49,9 @@ spec:
         prometheus.io/path: "/metrics"
         {{- end  }}
     spec:
+      {{- if .Values.forge.priorityClassName }}
+      priorityClassName: "{{ .Values.forge.priorityClassName}}"
+      {{- end }}
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.forge.fileStore.podSecurityContext | nindent 8 }}

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -528,6 +528,9 @@
                                 }
                             }
                         },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
                         "livenessProbe": {
                             "type": "object",
                             "properties": {

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -127,6 +127,8 @@ forge:
 
   tolerations: []
 
+  priorityClassName: ""
+
   logPassthrough: false
   customHostname:
     enabled: false


### PR DESCRIPTION
## Description

This pull request adds a possibility to configure `priorityClassName` for all deployments created by this Helm chart.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

