### PR TITLE
fix: Fix generating api secrets for Team Broker on deploy

### DIFF
--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -142,9 +142,14 @@ spec:
                     }
                 }
             }
-            api_key {
-              bootstrap_file = "/mounted/config/api-keys"
-            }
+    bootstrapAPIKeys:
+      - secretRef:
+        key:
+            secretName: emqx-config-secrets
+            secretKey: api-key-name
+        secret:
+            secretName: emqx-config-secrets
+            secretKey: api-key-secret
     coreTemplate:
         spec:
             {{- if .Values.forge.registrySecrets }}
@@ -215,7 +220,8 @@ metadata:
 type: Opaque
 data:
     EMQX_DASHBOARD__DEFAULT_PASSWORD: {{ "topSecret" | b64enc | quote }}
-    api-keys: {{ "flowfuse:verySecret:administrator" | b64enc | quote }} 
+    api-key-name: {{ "flowfuse" | b64enc | quote }} 
+    apit-key-secret:  {{ "verySecret" | b64enc | quote }} 
 ---
 {{- end }}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Move to supported way to add API tokens to broker.

This may break the dedicated instance already deployed, We may have to delete the emqx object before upgrading

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

