### PR TITLE
fix: secret reference indentation in EMQX definition

### DIFF
--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -144,12 +144,12 @@ spec:
             }
     bootstrapAPIKeys:
       - secretRef:
-        key:
-            secretName: emqx-config-secrets
-            secretKey: api-key-name
-        secret:
-            secretName: emqx-config-secrets
-            secretKey: api-key-secret
+            key:
+                secretName: emqx-config-secrets
+                secretKey: api-key-name
+            secret:
+                secretName: emqx-config-secrets
+                secretKey: api-key-secret
     coreTemplate:
         spec:
             {{- if .Values.forge.registrySecrets }}


### PR DESCRIPTION
## Description

This pull request fixes the indentation in EMQX's `BootstrapAPIKey` definition ([source](https://docs.emqx.com/en/emqx-operator/latest/reference/v2beta1-reference.html#bootstrapapikey)).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

