### PR TITLE
fix: Allow existingSecret for PostgreSQL and SES email

### DIFF
--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Note: The value for key .Values.postgresql.auth.existingSecret is inherited from
 
 {{- define "forge.createSecret" -}}
 {{- if not (and .Values.postgresql.auth.existingSecret 
-    (not (and .Values.forge.email (not .Values.forge.email.smtp.existingSecret)))) -}}
+    (not (and .Values.forge.email ((and .Values.forge.email.smtp (not .Values.forge.email.smtp.existingSecret)))))) -}}
 true
 {{- else -}}
 false


### PR DESCRIPTION
fixes #498

## Description

<!-- Describe your changes in detail -->
Allows for PostgreSQL existingSecret with AWS SES email

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#498 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

