### PR TITLE
feat: add possibility to deploy emqx-exporter with FlowFuse helm chart

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -119,6 +119,7 @@ To use STMP to send email
   - `broker.listenersServiceTemplate` Service spec for the MQTT listeners
   - `broker.dashboardServiceTemplate` Service spec for the teamBroker admin console
   - `broker.existingSecret` name of existing Secret holding dashboard admin password and API key
+  - `broker.monitoring.emqxExporter.enabled` controls deployment of [emqx-exporter](https://github.com/emqx/emqx-exporter) (default `false`)
 
 ### Telemetry
 

--- a/helm/flowforge/templates/emqx-exporter-config.yaml
+++ b/helm/flowforge/templates/emqx-exporter-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.broker.monitoring.emqxExporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: emqx-exporter-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "forge.emqxExporterSelectorLabels" . | nindent 4 }}
+data:
+  config.yaml: |
+    metrics:
+      target: emqx-dashboard.{{ .Release.Namespace }}:18083
+      api_key: "flowfuse"
+      api_secret: <%= ENV['BOOTSTRAP_API_KEY'] %>
+    probes:
+      - target: emqx-listeners.default.svc.cluster.local:1883
+{{- end }}

--- a/helm/flowforge/templates/emqx-exporter.yaml
+++ b/helm/flowforge/templates/emqx-exporter.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.broker.monitoring.emqxExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{ include "forge.emqxExporterSelectorLabels" . | nindent 4 }}
+  name: emqx-exporter-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: metrics
+      port: 8085
+      targetPort: metrics
+  selector:
+    {{ include "forge.emqxExporterSelectorLabels" . | nindent 6 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emqx-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "forge.emqxExporterSelectorLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "forge.emqxExporterSelectorLabels" . | nindent 6 }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        {{ include "forge.emqxExporterSelectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/emqx-exporter-config.yaml") . | sha256sum }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+      initContainers:
+      - name: config
+        image: "ruby:2.7-slim"
+        imagePullPolicy: Always
+        command: ['sh', '-c', 'erb /tmpl/config.yaml > /config/config.yaml' ]
+        volumeMounts:
+          - name: configtemplate
+            mountPath: /tmpl
+          - name: configdir
+            mountPath: /config
+        env:
+          - name: BOOTSTRAP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: emqx-config-secrets
+                key: api_key_secret
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+      containers:
+        - name: exporter
+          image: emqx/emqx-exporter:0.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file
+            - /etc/emqx-exporter/config.yaml
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+          ports:
+            - containerPort: 8085
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          volumeMounts:
+            - name: configdir
+              mountPath: /etc/emqx-exporter/
+      volumes:
+        - name: configdir
+          emptyDir: {}
+        - name: configtemplate
+          configMap: 
+            name: emqx-exporter-config
+{{- end }}

--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -1,5 +1,7 @@
 {{- if and ( eq .Values.forge.broker.enabled true) ( eq .Values.forge.broker.teamBroker.enabled true )  -}}
-{{- if .Capabilities.APIVersions.Has "apps.emqx.io/v2beta1" }}
+{{- if not (.Capabilities.APIVersions.Has "apps.emqx.io/v2beta1") }}
+{{- fail "EMQX Operator not installed. Please install it or disable team broker before continuing" }}
+{{- end }}
 apiVersion: apps.emqx.io/v2beta1
 kind: EMQX
 metadata:
@@ -144,12 +146,12 @@ spec:
             }
     bootstrapAPIKeys:
       - secretRef:
-        key:
-            secretName: emqx-config-secrets
-            secretKey: api-key-name
-        secret:
-            secretName: emqx-config-secrets
-            secretKey: api-key-secret
+            key:
+                secretName: emqx-config-secrets
+                secretKey: api_key_name
+            secret:
+                secretName: emqx-config-secrets
+                secretKey: api_key_secret
     coreTemplate:
         spec:
             {{- if .Values.forge.registrySecrets }}
@@ -220,8 +222,8 @@ metadata:
 type: Opaque
 data:
     EMQX_DASHBOARD__DEFAULT_PASSWORD: {{ "topSecret" | b64enc | quote }}
-    api-key-name: {{ "flowfuse" | b64enc | quote }} 
-    apit-key-secret:  {{ "verySecret" | b64enc | quote }} 
+    api_key_name: {{ "flowfuse" | b64enc | quote }} 
+    api_key_secret: {{ include "emqx.bootstrapApiKeySecret" . | b64enc | quote }}
 ---
 {{- end }}
 apiVersion: networking.k8s.io/v1
@@ -258,7 +260,4 @@ spec:
         - {{ include "forge.brokerDomain" . }}
         secretName: {{ include "forge.brokerDomain" . }}
   {{- end }}
-{{- else }}
-  {{- fail "EMQX Operator not installed" }}
-{{- end }}
 {{- end }}

--- a/helm/flowforge/tests/deployment_test.yaml
+++ b/helm/flowforge/tests/deployment_test.yaml
@@ -2,16 +2,19 @@
 suite: test deployment object
 templates:
   - deployment.yaml
+  - configmap.yaml
 set:
   forge.domain: "chart-unit-tests.com"
 tests:
   - it: should create a deployment
+    template: deployment.yaml
     asserts:
       - hasDocuments:
           count: 1
       - isKind:
           of: Deployment
   - it: should create a deployment with init container
+    template: deployment.yaml
     asserts:
       - isNotNullOrEmpty:
           path: spec.template.spec.initContainers
@@ -20,6 +23,7 @@ tests:
           count: 1
 
   - it: should create an init container with two secrets
+    template: deployment.yaml
     asserts:
       - isNotNullOrEmpty:
           path: spec.template.spec.initContainers[0].env

--- a/helm/flowforge/tests/emqx-exporter_test.yaml
+++ b/helm/flowforge/tests/emqx-exporter_test.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test emqx-exporter deployment object
+templates:
+  - emqx-exporter.yaml
+  - emqx-exporter-config.yaml
+set:
+  forge.domain: "chart-unit-tests.com"
+  broker.monitoring.emqxExporter.enabled: true
+tests:
+  - it: should create a service for emqx-exporter
+    templates: 
+      - emqx-exporter.yaml
+    documentSelector:
+      path: metadata.name
+      value: emqx-exporter-service
+    asserts:
+      - isKind:
+          of: Service
+      - matchRegex:
+          path: metadata.name
+          pattern: ^emqx-exporter-service$
+  - it: should create a deployment for emqx-exporter
+    templates: 
+      - emqx-exporter.yaml
+    documentSelector:
+      path: metadata.name
+      value: emqx-exporter
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: ^emqx-exporter$
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+  - it: should create a configmap for emqx-exporter
+    templates: 
+      - emqx-exporter-config.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: emqx-exporter-config
+  - it: should create an init container with one secret
+    template: emqx-exporter.yaml
+    documentSelector:
+      path: metadata.name
+      value: emqx-exporter
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.spec.initContainers[0].env
+      - lengthEqual:
+          path: spec.template.spec.initContainers[0].env
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].env[0].name
+          value: BOOTSTRAP_API_KEY
+      - equal:
+          path: spec.template.spec.initContainers[0].env[*].valueFrom.secretKeyRef.name
+          value: emqx-config-secrets

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -981,6 +981,19 @@
                 },
                 "existingSecret": {
                     "type": "string"
+                },
+                "monitoring": {
+                    "type": "object",
+                    "properties": {
+                        "emqxExporter": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -160,5 +160,5 @@ broker:
   dashboardServiceTemplate: {}
   existingSecret: ''
   monitoring:
-    emqxExporter: 
+    emqxExporter:
       enabled: false

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -159,3 +159,6 @@ broker:
   listenersServiceTemplate: {}
   dashboardServiceTemplate: {}
   existingSecret: ''
+  monitoring:
+    emqxExporter: 
+      enabled: false


### PR DESCRIPTION
## Description

This pull request adds a possibility to deploy emqx-exporter with FlowFuse Helm chart.
Aditionally, it simplifies the logic behind checking the availability of APIs required by EMQX cluster.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/559

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

