### PR TITLE
fix: Add default MQTT max packet

### DIFF
--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -35,6 +35,9 @@ spec:
                     url = "http://forge.{{ .Release.Namespace }}/api/comms/v2/auth"
                 }
             ]
+            mqtt {
+                max_packet_size: 128MB
+            }
             authorization {
                 cache {
                     enable = true


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Set it to 128MB (half max, but more then 1MB default)

https://docs.emqx.com/en/emqx/v5.8.2/hocon/#V-mqtt-S-mqtt-max_packet_size

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FFC issues

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

