### PR TITLE
ci: Add helm chart unit tests to `Helm chart validation` workflow

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -102,8 +102,9 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
+          check_name: 'Helm chart unit tests'
           report_paths: 'junit-results.xml'
-
+          detailed_summary: true
 
   scan:
     name: Scan chart

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -98,12 +98,11 @@ jobs:
         run: |
           helm unittest ./helm/flowforge -t JUnit -o junit-results.xml
 
-      - name: Upload test results
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
         if: always()
-        uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-results
-          path: junit-results.xml
+          report_paths: 'junit-results.xml'
 
 
   scan:

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -17,7 +17,6 @@ jobs:
   lint:
     name: Lint and install chart
     runs-on: ubuntu-latest
-    if: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -81,6 +81,31 @@ jobs:
         run: |
           helm template flowforge ./helm/flowforge --set forge.domain=example.com | kubectl apply --validate=true -f -
 
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      
+      - name: Install unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
+      - name: Run unit tests
+        run: |
+          helm unittest ./helm/flowforge -t JUnit -o junit-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-results
+          path: junit-results.xml
+
+
   scan:
     name: Scan chart
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -17,6 +17,7 @@ jobs:
   lint:
     name: Lint and install chart
     runs-on: ubuntu-latest
+    if: false
 
     steps:
       - name: Checkout

--- a/helm/flowforge/tests/broker_test.yaml
+++ b/helm/flowforge/tests/broker_test.yaml
@@ -12,7 +12,7 @@ tests:
     documentIndex: 0
     asserts:
       - isKind:
-          of: Deployment
+          of: Secret
       - equal:
           path: spec.template.spec.containers[?(@.name == "broker")].image
           value: iegomez/mosquitto-go-auth

--- a/helm/flowforge/tests/broker_test.yaml
+++ b/helm/flowforge/tests/broker_test.yaml
@@ -12,7 +12,7 @@ tests:
     documentIndex: 0
     asserts:
       - isKind:
-          of: Secret
+          of: Deployment
       - equal:
           path: spec.template.spec.containers[?(@.name == "broker")].image
           value: iegomez/mosquitto-go-auth


### PR DESCRIPTION
## Description

This pull request adds a job to `Helm chart validation` workflow responsible for running unit tests against FlowFuse Helm chart.
Tests are exected with `unittest` helm plugin.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/507

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

