### PR TITLE
fix: Separate project's and core app ingress annotations

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -35,6 +35,7 @@ For other values please refer to the documentation below.
  - `forge.projectNetworkPolicy.enabled` specified if [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) should be created for project pods ( default `false`)
  - `forge.projectNetworkPolicy.ingress` a list of ingress rules for the [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) applied on project pods ( default `[]`)
  - `forge.projectNetworkPolicy.egress` a list of egress rules for the [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) applied in project pods ( default `[]`)
+ - `forge.projectIngressAnnotations` ingress annotations for project instances (default is `{}`)
  - `forge.managementSelector` a collection of labels and values to filter nodes the Forge App will run on (default `role: management`)
  - `forge.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the core application pod
  - `forge.license` FlowForge EE license string (optional, default not set)

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -87,7 +87,10 @@ spec:
         {{ end -}}
         imagePullPolicy: Always
         env:
-        {{- if .Values.ingress.annotations }}
+        {{- if .Values.forge.projectIngressAnnotations }}
+        - name: INGRESS_ANNOTATIONS
+          value: {{ .Values.forge.projectIngressAnnotations | toJson | quote }}
+        {{- else if .Values.ingress.annotations }}
         - name: INGRESS_ANNOTATIONS
           value: {{ .Values.ingress.annotations | toJson | quote }}
         {{- end }}

--- a/helm/flowforge/tests/deployment_test.yaml
+++ b/helm/flowforge/tests/deployment_test.yaml
@@ -13,6 +13,7 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
   - it: should create a deployment with init container
     template: deployment.yaml
     asserts:
@@ -39,3 +40,36 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].env[*].valueFrom.secretKeyRef.name
           value: flowfuse-secrets
+
+  - it: should create a deployment without INGRESS_ANNOTATIONS environmental variable
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env[?(@.name == "INGRESS_ANNOTATIONS")]
+    
+  - it: should create container with INGRESS_ANNOTATIONS env and value from `ingress.annotations` 
+    template: deployment.yaml
+    set:
+      ingress.annotations:
+        customIngressAnnotation: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGRESS_ANNOTATIONS
+            value: '{"customIngressAnnotation":"true"}'
+
+  - it: should create container with INGRESS_ANNOTATIONS env and value `forge.projectIngressAnnotations`
+    template: deployment.yaml
+    set:
+      ingress.annotations:
+        customIngressAnnotation: "false"
+      forge.projectIngressAnnotations:
+        customProjectAnnotation: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INGRESS_ANNOTATIONS
+            value: '{"customProjectAnnotation":"true"}'
+  

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -142,6 +142,9 @@
                     },
                     "default": []
                 },
+                "projectIngressAnnotations": {
+                    "type": "object"
+                },
                 "managementSelector": {
                     "type": "object"
                 },

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -8,6 +8,7 @@ forge:
   projectDeploymentTolerations: []
   projectNetworkPolicy:
     enabled: false
+  projectIngressAnnotations: {}
   managementSelector:
     role: management
   telemetry:


### PR DESCRIPTION
## Description

This pull request separates the ingress annotations for the project's (NR instances) and the core application.
Custom annotations for NR instances can now be defined using the `forge.projectIngressAnnotation` variable.
To prevent breaking changes, the existing `ingress.annotations` will continue to be used as the value for the `INGRESS_ANNOTATIONS` environment variable within the core application if `forge.projectIngressAnnotation` is not defined.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/475

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

