### PR TITLE
chore(ci): Remove unused deployment jobs

### DIFF
--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -112,39 +112,3 @@ jobs:
           git add ./production/flowfuse-values.yaml
           git commit -m "Update file-server production image to ${{ needs.upload-production-image.outputs.image }}"
           git push origin main
-
-  deploy-stage:
-    # if: github.ref_name == 'main'
-    if: false
-    name: Deploy to staging environment
-    needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.37.0
-    with:
-      environment: stage
-      service_name: 'file-server'
-      deployment_name: 'flowforge-file'
-      container_name: 'file-storage'
-      image: ${{ needs.build.outputs.image }}
-    secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
-
-  deploy-prod:
-    # if: github.ref_name == 'main'
-    if: false
-    name: Deploy to production environment
-    needs: [build, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.37.0
-    with:
-      environment: production
-      service_name: 'file-server'
-      deployment_name: 'flowforge-file'
-      container_name: 'file-storage'
-      image: ${{ needs.build.outputs.image }}
-    secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -118,39 +118,3 @@ jobs:
           git add ./production/flowfuse-values.yaml
           git commit -m "Update forge production image to ${{ needs.upload-production-image.outputs.image }}"
           git push origin main
-  
-  deploy-stage:
-    # if: github.ref_name == 'main'
-    if: false
-    name: Deploy to staging environment
-    needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.37.0
-    with:
-      environment: stage
-      service_name: 'forge-k8s'
-      deployment_name: flowforge
-      container_name: forge
-      image: ${{ needs.build-multi-architecture.outputs.image }}
-    secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}
-  
-  deploy-prod:
-    # if: github.ref_name == 'main'
-    if: false
-    name: Deploy to production environment
-    needs: [build, deploy-stage]
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.37.0
-    with:
-      environment: production
-      service_name: 'forge-k8s'
-      deployment_name: flowforge
-      container_name: forge
-      image: ${{ needs.build-multi-architecture.outputs.image }}
-    secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-      temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
-      eks_cluster_name: ${{ secrets.EKS_CLUSTER_NAME }}


### PR DESCRIPTION
## Description

This pull request removes old deployment approach, which relies on updating pod's image tag directly on the kubernetes cluster, from core app and fileServer apps deployment workflows. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

