### PR TITLE
Add stable tags for different NR versions

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ github.event.inputs.version }}
+            type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=3.0.x
           flavor: |
             latest=true
           images: |
@@ -126,6 +127,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-2.2.3,value=${{ github.event.inputs.version }}
+            type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=2.2.x
           flavor: |
             latest=false
           images: |
@@ -162,6 +164,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-3.1.x,value=${{ github.event.inputs.version }}
+            type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=3.1.x
           flavor: |
             latest=false
           images: |
@@ -198,6 +201,7 @@ jobs:
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-4.0.x,value=${{ github.event.inputs.version }}
+            type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=4.0.x
           flavor: |
             latest=false
           images: |


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This is so we can change the default NR stack in docker and k8s installs, it should add the following tags that track the last release.

- latest-2.2.x
- latest-3.0.x
- latest-3.1.x
- latest-4.0.x

## Related Issue(s)

<!-- What issue does this PR relate to? -->
NA

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

