### PR TITLE
chore: Add config option for team broker hostname

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -95,6 +95,7 @@ To use STMP to send email
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
   - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mqtt.[forge.domain]`)
   - `forge.broker.teamBroker.enabled` Enables Team Broker feature (default `false`)
+  - `forge.broker.teamBroker.host` Sets the hostname for the Team Broker (default `broker.[forge.domain]`)
   - `forge.broker.createMetricsUser` defines if a dedicated MQTT user with broker metrics collection permissions should be created (default `true`)
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -95,7 +95,6 @@ To use STMP to send email
   - `forge.broker.public_url` URL to access the broker from outside the cluster (default `ws://mqtt.[forge.domain]`, uses `wss://` if `forge.https` is `true`)
   - `forge.broker.hostname` the custom Fully Qualified Domain Name (FQDN) where the broker will be hosted (default `mqtt.[forge.domain]`)
   - `forge.broker.teamBroker.enabled` Enables Team Broker feature (default `false`)
-  - `forge.broker.teamBroker.host` Sets the hostname for the Team Broker (default `broker.[forge.domain]`)
   - `forge.broker.createMetricsUser` defines if a dedicated MQTT user with broker metrics collection permissions should be created (default `true`)
   - `forge.broker.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the broker pod
   - `forge.broker.resources` allows to configure [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the broker container
@@ -123,6 +122,7 @@ To use STMP to send email
   - `broker.dashboardServiceTemplate` Service spec for the teamBroker admin console
   - `broker.existingSecret` name of existing Secret holding dashboard admin password and API key
   - `broker.monitoring.emqxExporter.enabled` controls deployment of [emqx-exporter](https://github.com/emqx/emqx-exporter) (default `false`)
+  - `broker.hostname` Sets the hostname for the Team Broker (default `broker.[forge.domain]`)
 
 ### Telemetry
 

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -185,8 +185,8 @@ Configure broker domain
 Team Broker default Hostname
 */}}
 {{- define "forge.teamBrokerHost" -}}
-{{- if ((.Values.broker).teamBroker).host  -}}
-    {{ .Values.broker.teamBroker.host }}
+{{- if (.Values.broker).hostname  -}}
+    {{ .Values.broker.hostname }}
 {{- else -}}
     {{ printf "%s.%s" "broker" .Values.forge.domain }}
 {{- end -}}

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -185,8 +185,8 @@ Configure broker domain
 Team Broker default Hostname
 */}}
 {{- define "forge.teamBrokerHost" -}}
-{{- if (((.Values.forge).broker).teamBroker).host  -}}
-    {{ .Values.forge.broker.teamBroker.host }}
+{{- if ((.Values.broker).teamBroker).host  -}}
+    {{ .Values.broker.teamBroker.host }}
 {{- else -}}
     {{ printf "%s.%s" "broker" .Values.forge.domain }}
 {{- end -}}

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -182,6 +182,17 @@ Configure broker domain
 {{- end -}}
 
 {{/*
+Team Broker default Hostname
+*/}}
+{{- define "forge.teamBrokerHost" -}}
+{{- if (((.Values.forge).broker).teamBroker).host  -}}
+    {{ .Values.forge.broker.teamBroker.host }}
+{{- else -}}
+    {{ printf "%s.%s" "broker" .Values.forge.domain }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Configure emqx bootstrap api secret
 */}}
 {{- define "emqx.bootstrapApiKeySecret" -}}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -173,7 +173,8 @@ data:
       {{ end -}}
       {{ if or .Values.forge.broker.teamBroker.enabled .Values.forge.broker.teamBroker.uiOnly }}
       teamBroker:
-        enabled: true 
+        enabled: true
+        host: {{ include "forge.teamBrokerHost" . }}
       {{ end -}}
     {{- end }}
     logging:

--- a/helm/flowforge/templates/emqx.yaml
+++ b/helm/flowforge/templates/emqx.yaml
@@ -37,6 +37,7 @@ spec:
             ]
             mqtt {
                 max_packet_size: 128MB
+                max_awaiting_rel = infinity
             }
             authorization {
                 cache {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Allow team broker hostname to be set in the flowforge.yml

Defaults to `broker`.[forge.domain] 

(Also set EMQX config option)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [x] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production (NA as default matches)

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

