### PR TITLE
fix: Allow to set empty `securityContext` for all deployments

### DIFF
--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -32,8 +32,10 @@ spec:
       priorityClassName: "{{ .Values.forge.priorityClassName}}"
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.forge.broker.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.forge.broker.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: broker
         image: {{ .Values.forge.broker.image }}

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -40,8 +40,10 @@ spec:
       {{- end }}
       serviceAccountName: flowforge
       automountServiceAccountToken: true 
+      {{- if .Values.forge.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.forge.podSecurityContext | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: config
         image: "ruby:2.7-slim"

--- a/helm/flowforge/templates/file-storage.yml
+++ b/helm/flowforge/templates/file-storage.yml
@@ -53,8 +53,10 @@ spec:
       priorityClassName: "{{ .Values.forge.priorityClassName}}"
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.forge.fileStore.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.forge.fileStore.podSecurityContext | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: config
         image: "ruby:2.7-slim"


### PR DESCRIPTION
## Description

This pull requests adjusts the way how `securityContext` is created in each deployment managed by helm chart.
This change allows to provide no values for each `securityContext` . Since we provide pre-defined values for each of the deployment, now there will be a posibility to completly remove a `securityContenxt` values by assigining `null` value to the `forge.podSecurityContext`.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/526

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

