### PR TITLE
feat: Allow File Storage database name to be customised  

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -274,6 +274,7 @@ editors:
 - `postgresql.auth.password` - the password to use to connect to the database (default `Zai1Wied`)
 - `postgresql.auth.database` - the database to use (default `flowforge`)
 - `postgresql.auth.postgresPassword` - the password to use for the postgres user (default `Moomiet0`)
+- `postgresql.auth.fileStoreDatabase` - the database to use bt the File Storage servive (default `ff-context`)
 - `postgresql.auth.existingSecret` - the name of an Kubernetes secret object with database credentials (If `postgresql.auth.existingSecret` is set, `postgresql.auth.password` and `postgresql.auth.postgresPassword` values are ignored; default not set)
 
 

--- a/helm/flowforge/templates/file-storage-configmap.yaml
+++ b/helm/flowforge/templates/file-storage-configmap.yaml
@@ -32,7 +32,7 @@ data:
         host: {{ include "forge.databaseHost" . }}
         port: {{ .Values.postgresql.port | default 5432 }}
         username: {{ .Values.postgresql.auth.username }}
-        database: ff-context
+        database: {{ .Values.postgresql.auth.fileStoreDatabase }}
         password: <%= ENV['PGPASSWORD'] %>
         {{- end }}
         {{- if eq .Values.forge.fileStore.context.options.type "sqlite" }}
@@ -61,8 +61,8 @@ data:
     # apk add --no-cache postgresql14-client
     psql -v ON_ERROR_STOP=1 -h {{ .Release.Name }}-postgresql -U postgres postgres <<-ESQL
     SELECT datname FROM pg_database WHERE datistemplate = false;
-    SELECT 'CREATE DATABASE "ff-context"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'ff-context')\gexec
-    GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
+    SELECT 'CREATE DATABASE "{{ .Values.postgresql.auth.fileStoreDatabase }}"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{{ .Values.postgresql.auth.fileStoreDatabase }}')\gexec
+    GRANT ALL PRIVILEGES ON DATABASE "{{ .Values.postgresql.auth.fileStoreDatabase }}" TO "{{ .Values.postgresql.auth.username }}";
     ESQL
 {{- end }}
 {{- end -}}

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -145,6 +145,7 @@ postgresql:
     username: forge
     password: Zai1Wied
     database: flowforge
+    fileStoreDatabase: ff-context
 
 ingress:
   annotations: {}


### PR DESCRIPTION
## Description

This pull request adds a possibility to specify custom database name used by the File Storage service. 
Additionally, it removes hardcoded database username from the initialisation script.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/305

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

