### PR TITLE
ci: Do not fail Helm chart release if container images workflow returns `queued` status

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -36,7 +36,7 @@ jobs:
                 echo "Release container images workflow failed"
                 exit 1
               fi
-            elif [[ "$status" == "in_progress" ]]; then
+            elif [[ "$status" == "in_progress" || "$status" == "queued" ]]; then
               echo "Release container images workflow is still running"
               sleep 60
             else


### PR DESCRIPTION
## Description

This pull request improves the `Release Helm Chart` workflow by properly handling the `queued` status which can be returned by Github once requested the status of the `Release container images` pipeline.

## Related Issue(s)

Fixes https://github.com/FlowFuse/helm/issues/539


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

