### PR TITLE
feat: Add possibility to customise service type created for project deployment

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -36,6 +36,7 @@ For other values please refer to the documentation below.
  - `forge.projectNetworkPolicy.ingress` a list of ingress rules for the [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) applied on project pods ( default `[]`)
  - `forge.projectNetworkPolicy.egress` a list of egress rules for the [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) applied in project pods ( default `[]`)
  - `forge.projectIngressAnnotations` ingress annotations for project instances (default is `{}`)
+ - `forge.projectServiceType` service type for project instances (default is `ClusterIP`)
  - `forge.managementSelector` a collection of labels and values to filter nodes the Forge App will run on (default `role: management`)
  - `forge.affinity` allows to configure [affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the core application pod
  - `forge.license` FlowForge EE license string (optional, default not set)

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -50,6 +50,13 @@ data:
         {{- if .Values.forge.projectNamespace }}
         projectNamespace: {{ .Values.forge.projectNamespace }}
         {{- end }}
+        {{ if .Values.forge.projectServiceType }}
+        service:
+          type: {{ .Values.forge.projectServiceType }}
+        {{- end }}
+        {{- if and (eq .Values.forge.projectServiceType "NodePort") (.Values.forge.projectServiceNodePort) }}
+          nodePort: {{ .Values.forge.projectServiceNodePort }}
+        {{- end }}
         {{- if .Values.forge.cloudProvider }}
         cloudProvider: {{ .Values.forge.cloudProvider }}
         {{- end }}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -54,9 +54,6 @@ data:
         service:
           type: {{ .Values.forge.projectServiceType }}
         {{- end }}
-        {{- if and (eq .Values.forge.projectServiceType "NodePort") (.Values.forge.projectServiceNodePort) }}
-          nodePort: {{ .Values.forge.projectServiceNodePort }}
-        {{- end }}
         {{- if .Values.forge.cloudProvider }}
         cloudProvider: {{ .Values.forge.cloudProvider }}
         {{- end }}


### PR DESCRIPTION
## Description

This pull requests adds the `forge.projectServiceType` value which allows to define a service type created for NodeRED deployments. Currently, only `ClusterIP` (default value from the Kubernetes driver) and `NodePort` service types are supported.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4041

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

