### PR TITLE
feat: Add possibility to create NodePort-type services for forge and broker deployments

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -54,7 +54,7 @@ For other values please refer to the documentation below.
  - `forge.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the core application deployment (default `[]`)
  - `forge.priorityClassName` allows to set [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) for all deployments created by this Helm chart (default not set)
  - `forge.service.type` allows to set the service type for the core application service (default `ClusterIP`)
- - `forge.servvide.nodePort` allows to set custom nodePort value when `forge.service.type` value is set to `NodePort` (default not set)
+ - `forge.service.nodePort` allows to set custom nodePort value when `forge.service.type` value is set to `NodePort` (default not set)
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.

--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -53,6 +53,8 @@ For other values please refer to the documentation below.
  - `forge.replicas` allows the number of instances of the FlowFuse App to be set. Scaling only supported with ingress-nginx controller (default `1`)
  - `forge.tolerations` allows to configure [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the core application deployment (default `[]`)
  - `forge.priorityClassName` allows to set [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) for all deployments created by this Helm chart (default not set)
+ - `forge.service.type` allows to set the service type for the core application service (default `ClusterIP`)
+ - `forge.servvide.nodePort` allows to set custom nodePort value when `forge.service.type` value is set to `NodePort` (default not set)
 
  
 note: `forge.projectSelector` and `forge.managementSelector` defaults mean that you must have at least 2 nodes in your cluster and they need to be labeled before installing.
@@ -123,6 +125,9 @@ To use STMP to send email
   - `broker.existingSecret` name of existing Secret holding dashboard admin password and API key
   - `broker.monitoring.emqxExporter.enabled` controls deployment of [emqx-exporter](https://github.com/emqx/emqx-exporter) (default `false`)
   - `broker.hostname` Sets the hostname for the Team Broker (default `broker.[forge.domain]`)
+  - `broker.service.type` allows to set the service type for the Team Broker service (default `ClusterIP`)
+  - `broker.service.mqtt.nodePort` allows to set custom nodePort value for `mqtt` port when `broker.service.type` value is set to `NodePort` (default not set)
+  - `broker.service.ws.nodePort` allows to set custom nodePort value for `ws` port when `broker.service.type` value is set to `NodePort` (default not set)
 
 ### Telemetry
 

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -43,7 +43,13 @@ Broker Selector labels
 {{ include "forge.commonSelectorLabels" . }}
 app.kubernetes.io/component: "broker"
 */}}
+{{- if and ( eq .Values.forge.broker.enabled true) ( eq .Values.forge.broker.teamBroker.enabled false ) -}}
 app: flowforge-broker
+{{- else -}}
+apps.emqx.io/db-role: core
+apps.emqx.io/instance: emqx
+apps.emqx.io/managed-by: emqx-operator
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/helm/flowforge/templates/broker.yaml
+++ b/helm/flowforge/templates/broker.yaml
@@ -138,6 +138,24 @@ metadata:
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.broker.service.type }}
+  {{- if eq .Values.broker.service.type "NodePort" }}
+  ports:
+  - port: 1883
+    targetPort: 1883
+    protocol: TCP
+    name: mqtt-native
+    {{- if (.Values.broker.service.mqtt).nodePort }}
+    nodePort: {{ .Values.broker.service.mqtt.nodePort }}
+    {{- end }}
+  - port: 1884
+    targetPort: 1884
+    protocol: TCP
+    name: mqtt-ws
+    {{- if (.Values.broker.service.ws).nodePort }}
+    nodePort: {{ .Values.broker.service.ws.nodePort }}
+    {{- end }}
+  {{- else }}
   ports:
   - port: 1883
     targetPort: 1883
@@ -147,12 +165,7 @@ spec:
     targetPort: 1884
     protocol: TCP
     name: mqtt-ws
+  {{- end }}
   selector:
-    {{- if and ( eq .Values.forge.broker.enabled true) ( eq .Values.forge.broker.teamBroker.enabled false ) -}}
     {{- include "forge.brokerSelectorLabels" . | nindent 4 }}
-    {{- else }}
-    apps.emqx.io/db-role: core
-    apps.emqx.io/instance: emqx
-    apps.emqx.io/managed-by: emqx-operator
-    {{- end }}
 {{- end -}}

--- a/helm/flowforge/templates/service-ingress.yaml
+++ b/helm/flowforge/templates/service-ingress.yaml
@@ -7,12 +7,23 @@ metadata:
   labels:
   {{- include "forge.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.forge.service.type }}
   selector:
     {{- include "forge.forgeSelectorLabels" . | nindent 6 }}
+  {{- if eq .Values.forge.service.type "NodePort" }}
   ports:
   - protocol: TCP
     port: 80
     targetPort: 3000
+    {{- if .Values.forge.service.nodePort }}
+    nodePort: {{ .Values.forge.service.nodePort }}
+    {{- end }}
+  {{- else }}
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000
+  {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm/flowforge/tests/broker_test.yaml
+++ b/helm/flowforge/tests/broker_test.yaml
@@ -51,3 +51,44 @@ tests:
             apps.emqx.io/db-role: core
             apps.emqx.io/instance: emqx
             apps.emqx.io/managed-by: emqx-operator
+
+  - it: should create a NodePort-type broker service
+    template: broker.yaml
+    documentIndex: 1
+    set:
+      broker.service.type: NodePort
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: flowforge-broker
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should create a NodePort-type broker service with custom mqtt and ws NodePorts
+    template: broker.yaml
+    documentIndex: 1
+    set:
+      broker.service:
+        type: NodePort
+        mqtt:
+          nodePort: 30001
+        ws:
+          nodePort: 30002
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: flowforge-broker
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[?(@.name == "mqtt-native")].nodePort
+          value: 30001
+      - equal:
+          path: spec.ports[?(@.name == "mqtt-ws")].nodePort
+          value: 30002

--- a/helm/flowforge/tests/service_test.yaml
+++ b/helm/flowforge/tests/service_test.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: test deployment object
+suite: test forge service object
 templates:
   - service-ingress.yaml
 set:

--- a/helm/flowforge/tests/service_test.yaml
+++ b/helm/flowforge/tests/service_test.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test deployment object
+templates:
+  - service-ingress.yaml
+set:
+  forge.domain: "chart-unit-tests.com"
+tests:
+  - it: should create a NodePort-type forge service
+    documentIndex: 0
+    set:
+      forge.service.type: NodePort
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: forge
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should create a NodePort-type forge service with custom NodePort value
+    documentIndex: 0
+    set:
+      forge.service:
+        type: NodePort
+        nodePort: 30001
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: forge
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30001

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -929,6 +929,18 @@
                     "then": {
                         "required": ["url", "admin"]
                     }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["type"]
                 }
             },
             "required": [
@@ -1033,6 +1045,31 @@
                             }
                         }
                     }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "mqtt": {
+                            "type": "object",
+                            "properties": {
+                                "nodePort": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "ws": {
+                            "type": "object",
+                            "properties": {
+                                "nodePort": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "required": ["type"]
                 }
             }
         }

--- a/helm/flowforge/values.yaml
+++ b/helm/flowforge/values.yaml
@@ -137,6 +137,9 @@ forge:
 
   assistant: {}
 
+  service:
+    type: ClusterIP
+
 postgresql:
   image:
     tag: "14.10.0-debian-11-r30"
@@ -165,3 +168,5 @@ broker:
   monitoring:
     emqxExporter:
       enabled: false
+  service:
+    type: ClusterIP


### PR DESCRIPTION
## Description

This pull request adds possibility to create NodePort services for both forge and broker deployments. Additionally, it adds possibility to define static ports if NodePort serices is about to be created.
It also moves the logic responsible for handling selector labels for broker service to the helpers file.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/4041

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

