### PR TITLE
ci: Add possibility to push Node-RED container images to private ECR

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -146,13 +146,29 @@ jobs:
           readme-filepath: ./helm/node-red-container/README.md
 
   build_nodered_container_223:
-    if: false
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_ECR_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
+          role-session-name: GithubActionsRoleSession
+          role-duration-seconds: 900
+        
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
       - name: Docker Meta Data
         id: meta
         uses: docker/metadata-action@v5
@@ -163,17 +179,21 @@ jobs:
           flavor: |
             latest=false
           images: |
-            flowforge/node-red
-            flowfuse/node-red
+            devopswizard/node-red
+            ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
+
       - name: docker login
         uses: docker/login-action@v3
         with:
-          username: flowforge
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          username: devopswizard
+          password: ${{ secrets.DO_DOCKER_HUB_PASSWORD }}
+
       - name: Build and push FlowForge Application container
         uses: docker/build-push-action@v6.14.0
         with:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -6,8 +6,14 @@ on:
         description: 'Version to release'
         required: true
 
+env:
+  AWS_ECR_ROLE_NAME: "ECR_push_pull_images"
+  AWS_ECR_REGION: "eu-west-1"
+  AWS_ECR_NODE_RED_REPOSITORY_NAME: "flowforge/node-red"
+
 jobs:
   build_application_container:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,6 +76,21 @@ jobs:
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_ECR_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
+          role-session-name: GithubActionsRoleSession
+          role-duration-seconds: 900
+        
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
       - name: Docker Meta Data
         id: meta
         uses: docker/metadata-action@v5
@@ -80,18 +101,22 @@ jobs:
           flavor: |
             latest=true
           images: |
-            flowforge/node-red
-            flowfuse/node-red
+            devopswizard/node-red
+            ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
-      - name: docker login
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: flowforge
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push FlowForge Application container
+          username: devopswizard
+          password: ${{ secrets.DO_DOCKER_HUB_PASSWORD }}
+  
+      - name: Build and push Node-RED container
         uses: docker/build-push-action@v6.14.0
         with:
           context: helm/node-red-container
@@ -99,14 +124,18 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7 
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+
       - name: Push README
+        if: false
         uses: peter-evans/dockerhub-description@v4
         with:
           repository: flowforge/node-red
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           readme-filepath: ./helm/node-red-container/README.md
+
       - name: Push README flowfuse
+        if: false
         uses: peter-evans/dockerhub-description@v4
         with:
           repository: flowfuse/node-red
@@ -115,6 +144,7 @@ jobs:
           readme-filepath: ./helm/node-red-container/README.md
 
   build_nodered_container_223:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -152,6 +182,7 @@ jobs:
           push: true
 
   build_nodered_container_31:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -189,6 +220,7 @@ jobs:
           push: true
 
   build_nodered_container_40:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -226,6 +258,7 @@ jobs:
           push: true
 
   build_file_server_container:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build_application_container:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -74,7 +74,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
@@ -92,6 +93,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Meta Data
         id: meta
@@ -111,12 +118,6 @@ jobs:
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: devopswizard
-          password: ${{ secrets.DO_DOCKER_HUB_PASSWORD }}
   
       - name: Build and push Node-RED container
         uses: docker/build-push-action@v6.14.0
@@ -128,7 +129,6 @@ jobs:
           push: true
 
       - name: Push README
-        if: false
         uses: peter-evans/dockerhub-description@v4
         with:
           repository: flowforge/node-red
@@ -137,7 +137,6 @@ jobs:
           readme-filepath: ./helm/node-red-container/README.md
 
       - name: Push README flowfuse
-        if: false
         uses: peter-evans/dockerhub-description@v4
         with:
           repository: flowfuse/node-red
@@ -150,7 +149,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
@@ -169,6 +169,12 @@ jobs:
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Docker Meta Data
         id: meta
         uses: docker/metadata-action@v5
@@ -179,7 +185,8 @@ jobs:
           flavor: |
             latest=false
           images: |
-            devopswizard/node-red
+            flowforge/node-red
+            flowfuse/node-red
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU
@@ -188,13 +195,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: docker login
-        uses: docker/login-action@v3
-        with:
-          username: devopswizard
-          password: ${{ secrets.DO_DOCKER_HUB_PASSWORD }}
-
-      - name: Build and push FlowForge Application container
+      - name: Build and push Node-RED container
         uses: docker/build-push-action@v6.14.0
         with:
           context: helm/node-red-container
@@ -204,13 +205,36 @@ jobs:
           push: true
 
   build_nodered_container_31:
-    if: false
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_ECR_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
+          role-session-name: GithubActionsRoleSession
+          role-duration-seconds: 900
+        
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Docker Meta Data
         id: meta
         uses: docker/metadata-action@v5
@@ -223,16 +247,15 @@ jobs:
           images: |
             flowforge/node-red
             flowfuse/node-red
+            ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
-      - name: docker login
-        uses: docker/login-action@v3
-        with:
-          username: flowforge
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push FlowForge Application container
+
+      - name: Build and push Node-RED container
         uses: docker/build-push-action@v6.14.0
         with:
           context: helm/node-red-container
@@ -242,13 +265,36 @@ jobs:
           push: true
 
   build_nodered_container_40:
-    if: false
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_ECR_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
+          role-session-name: GithubActionsRoleSession
+          role-duration-seconds: 900
+        
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Docker Meta Data
         id: meta
         uses: docker/metadata-action@v5
@@ -261,16 +307,15 @@ jobs:
           images: |
             flowforge/node-red
             flowfuse/node-red
+            ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
-      - name: docker login
-        uses: docker/login-action@v3
-        with:
-          username: flowforge
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build and push FlowForge Application container
+
+      - name: Build and push Node-RED container
         uses: docker/build-push-action@v6.14.0
         with:
           context: helm/node-red-container
@@ -280,7 +325,6 @@ jobs:
           push: true
 
   build_file_server_container:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -110,7 +110,8 @@ jobs:
           flavor: |
             latest=true
           images: |
-            devopswizard/node-red
+            flowforge/node-red
+            flowfuse/node-red
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -71,6 +71,8 @@ jobs:
 
   build_nodered_container:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

This pull request extends `Release container images` by adding steps responsible for pushing Node-RED container images to FlowFuse private Elastic Container Registry.

## Related Issue(s)

Closes https://github.com/FlowFuse/CloudProject/issues/640

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

