### PR TITLE
fix: typo in `npmRegistry.image` reference

### DIFF
--- a/helm/flowforge/templates/npm-registry.yaml
+++ b/helm/flowforge/templates/npm-registry.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
       - name: flowfuse-npm-registry
         {{- if .Values.npmRegistry.image }}
-        image: {{ .value.npmRegistry.image }}
+        image: {{ .Values.npmRegistry.image }}
         {{ else }}
         image: flowfuse/npm-registry:latest
         {{ end -}}


### PR DESCRIPTION
## Description

This pukk request fixes typo in flowfuse-npm-registry image use.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

