### PR TITLE
fix: Add better healthcheck probe path

### DIFF
--- a/helm/flowforge/templates/npm-registry.yaml
+++ b/helm/flowforge/templates/npm-registry.yaml
@@ -55,13 +55,13 @@ spec:
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
-            path: /
+            path: /-/all
             port: 4873
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
+            path: /-/all
             port: 4873
           initialDelaySeconds: 5
           periodSeconds: 10


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Use liveness and readiness probe path that returns 200 not 404