### PR TITLE
chore: Pin external actions to commit hash

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -15,7 +15,7 @@ jobs:
   build_application_container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
@@ -23,7 +23,7 @@ jobs:
       # will tag contianers with ${{ github.event.inputs.version }} and latest
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ github.event.inputs.version }}
@@ -34,19 +34,19 @@ jobs:
             flowfuse/forge-k8s
       # sets up multi platform emulators
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       # sets up docker buildx
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       # logs into docker hub
       - name: docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       # builds container
       - name: Build and push FlowForge Application container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/flowforge-container
           file: helm/flowforge-container/Dockerfile
@@ -54,14 +54,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
       - name: Push README
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowforge/forge-k8s
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           readme-filepath: ./helm/flowforge-container/README.md
       - name: Push README flowfuse
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowfuse/forge-k8s
           username: flowfuse
@@ -74,13 +74,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: ${{ env.AWS_ECR_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
@@ -89,19 +89,19 @@ jobs:
         
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ github.event.inputs.version }}
@@ -114,13 +114,13 @@ jobs:
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
   
       - name: Build and push Node-RED container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/node-red-container
           file: helm/node-red-container/Dockerfile
@@ -129,7 +129,7 @@ jobs:
           push: true
 
       - name: Push README
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowforge/node-red
           username: flowforge
@@ -137,7 +137,7 @@ jobs:
           readme-filepath: ./helm/node-red-container/README.md
 
       - name: Push README flowfuse
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowfuse/node-red
           username: flowfuse
@@ -150,13 +150,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: ${{ env.AWS_ECR_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
@@ -165,19 +165,19 @@ jobs:
         
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-2.2.3,value=${{ github.event.inputs.version }}
@@ -190,13 +190,13 @@ jobs:
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build and push Node-RED container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/node-red-container
           file: helm/node-red-container/Dockerfile-2.2.x
@@ -210,13 +210,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: ${{ env.AWS_ECR_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
@@ -225,19 +225,19 @@ jobs:
         
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-3.1.x,value=${{ github.event.inputs.version }}
@@ -250,13 +250,13 @@ jobs:
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build and push Node-RED container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/node-red-container
           file: helm/node-red-container/Dockerfile-3.1
@@ -270,13 +270,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: ${{ env.AWS_ECR_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/${{ env.AWS_ECR_ROLE_NAME }}
@@ -285,19 +285,19 @@ jobs:
         
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
           registries: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}"
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=-4.0.x,value=${{ github.event.inputs.version }}
@@ -310,13 +310,13 @@ jobs:
             ${{ steps.login-ecr.outputs.registry}}/${{ env.AWS_ECR_NODE_RED_REPOSITORY_NAME }}
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build and push Node-RED container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/node-red-container
           file: helm/node-red-container/Dockerfile-4.0
@@ -327,13 +327,13 @@ jobs:
   build_file_server_container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'flowfuse/helm'
           path: 'helm'
       - name: Docker Meta Data
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ github.event.inputs.version }}
@@ -343,16 +343,16 @@ jobs:
             flowforge/file-server
             flowfuse/file-server
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: docker login
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Build and push FlowForge File Server container
-        uses: docker/build-push-action@v6.14.0
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: helm/file-server
           file: helm/file-server/Dockerfile
@@ -360,14 +360,14 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           push: true
       - name: Push README
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowforge/file-server
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           readme-filepath: ./helm/file-server/README.md
       - name: Push README flowfuse
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
           repository: flowfuse/file-server
           username: flowfuse

--- a/.github/workflows/fileserver-container.yml
+++ b/.github/workflows/fileserver-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'file-server'
       package_dependencies: |
@@ -45,7 +45,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Upload image to staging registry
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'file-server'
@@ -63,7 +63,7 @@ jobs:
     if: github.ref_name == 'main'
     name: Upload image to production registry
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'file-server'
@@ -85,18 +85,18 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'FlowFuse/CloudProject'
           ref: 'main'
           token: ${{ steps.generate_token.outputs.token }}
       - name: Install yq
-        uses: alexellis/arkade-get@master
+        uses: alexellis/arkade-get@7cc6ec1b6d8fcfcf3cc8cac995973147bc5fabf7 # master
         with:
           yq: v4.42.1
       - name: Update images

--- a/.github/workflows/flowforge-container.yml
+++ b/.github/workflows/flowforge-container.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   build:
     name: Build single-architecture container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'forge-k8s'
       package_dependencies: |
@@ -47,15 +47,13 @@ jobs:
     if: github.ref_name == 'main'
     name: Upload image to staging registry
     needs: build
-    # needs: build-multi-architecture
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'forge-k8s'
       deployment_name: flowforge
       container_name: forge
       deploy: false
-      # image: ${{ needs.build-multi-architecture.outputs.image }}
       image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -66,16 +64,14 @@ jobs:
   upload-production-image:
     if: github.ref_name == 'main'
     name: Upload image to production registry
-    # needs: build-multi-architecture
     needs: build
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'forge-k8s'
       deployment_name: flowforge
       container_name: forge
       deploy: false
-      # image: ${{ needs.build-multi-architecture.outputs.image }}
       image: ${{ needs.build.outputs.image }}
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -91,18 +87,18 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'FlowFuse/CloudProject'
           ref: 'main'
           token: ${{ steps.generate_token.outputs.token }}
       - name: Install yq
-        uses: alexellis/arkade-get@master
+        uses: alexellis/arkade-get@7cc6ec1b6d8fcfcf3cc8cac995973147bc5fabf7 # master
         with:
           yq: v4.42.1
       - name: Update images

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           token: ${{ github.token }}
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Semantic Release
         id: semantic-release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -73,7 +73,7 @@ jobs:
             semantic-release-helm3@2.9.3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -20,22 +20,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.13.2
 
       - name: Install Python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.9
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
       - name: Add bitami repo
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create kind cluster
         if: "${{!startsWith(github.event.pull_request.title, 'feat: Release')}}"
-        uses: helm/kind-action@v1.11.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
 
       - name: Label cluster nodes
         if: "${{!startsWith(github.event.pull_request.title, 'feat: Release')}}"
@@ -65,17 +65,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.13.2
       
       - name: Create kind cluster
-        uses: helm/kind-action@v1.11.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
 
       - name: Validate chart
         run: |
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
       
       - name: Install unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
@@ -99,7 +99,7 @@ jobs:
           helm unittest ./helm/flowforge -t JUnit -o junit-results.xml
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1 # v5.5.0
         if: always()
         with:
           check_name: 'Helm chart unit tests'
@@ -121,18 +121,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
     
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.13.2
     
       - name: Scan chart with checkov
         if: matrix.tool == 'checkov'
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@8915e9071550c2d2dc56a011b9012b74ae42da12 # v12.2982.0
         with:
           directory: ${{ github.workspace }}/helm
           var_file: ${{ github.workspace }}/helm/flowforge/ci/default-values.yaml
@@ -167,6 +167,6 @@ jobs:
 
       - name: "Upload SARIF file"
         if: success() || failure()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
         with:
           sarif_file: results.sarif

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -15,6 +15,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/nodered-container.yml
+++ b/.github/workflows/nodered-container.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build-302:
     name: Build 3.0.2 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
@@ -49,7 +49,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -67,7 +67,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-302
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'node-red'
@@ -84,7 +84,7 @@ jobs:
 
   build-223:
     name: Build 2.2.3 container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-2.2.x
@@ -103,7 +103,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -121,7 +121,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-223
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'node-red'
@@ -138,7 +138,7 @@ jobs:
 
   build-310:
     name: Build 3.1.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-3.1
@@ -157,7 +157,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -175,7 +175,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-310
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'node-red'
@@ -192,7 +192,7 @@ jobs:
 
   build-40:
     name: Build 4.0.x container images
-    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.39.0
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile-4.0
@@ -211,7 +211,7 @@ jobs:
     name: Upload image to staging ECR
     if: github.ref_name == 'main'
     needs: build-40
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: stage
       service_name: 'node-red'
@@ -229,7 +229,7 @@ jobs:
     name: Upload image to production ECR
     if: github.ref_name == 'main'
     needs: build-40
-    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.38.0
+    uses: flowfuse/github-actions-workflows/.github/workflows/deploy_container_image.yml@v0.39.0
     with:
       environment: production
       service_name: 'node-red'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: 16.x
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
       with:
         version: v3.11.0
     - name: test


### PR DESCRIPTION
## Description

This pull request pins external GitHub Actions to commit hashes instead of tags in all workflows.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/663

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

