### PR TITLE
feat: Change the flowfuse/node-red:latest tag to Node-RED 4.0.x

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -107,7 +107,7 @@ jobs:
             type=raw,enable=true,priority=200,prefix=,suffix=,value=${{ github.event.inputs.version }}
             type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=3.0.x
           flavor: |
-            latest=true
+            latest=false
           images: |
             flowforge/node-red
             flowfuse/node-red
@@ -303,7 +303,7 @@ jobs:
             type=raw,enable=true,priority=200,prefix=,suffix=-4.0.x,value=${{ github.event.inputs.version }}
             type=raw,enable=true,priority=200,prefix=latest-,suffix=,value=4.0.x
           flavor: |
-            latest=false
+            latest=true
           images: |
             flowforge/node-red
             flowfuse/node-red

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This container holds the FlowFuse App and the Kubernetes Driver
 
 ### Node-RED container
 
-This is a basic Node-RED image with the FlowFuse Lanucher and the required Node-RED plugins to talk to the FlowFuse Platform
+This is a basic Node-RED image with the FlowFuse Launcher and the required Node-RED plugins to talk to the FlowFuse Platform
 
 ### File Server container
 


### PR DESCRIPTION
fixes FlowFuse/flowfuse#5361

## Description

<!-- Describe your changes in detail -->
Change the `flowfuse/node-red:latest` tag to point at the NR 4.0.x NodeJS 20 based containers.

Also fixes a README.md typo I spotted

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#5361

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

