### PR TITLE
feat: Add writable `/tmp` directory for forge pod

### DIFF
--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -141,6 +141,8 @@ spec:
         - name: NODE_ENV
           value: production
         volumeMounts:
+        - name: tempdir
+          mountPath: /tmp
         - name: configdir
           mountPath: /usr/src/forge/etc
         {{- if .Values.forge.privateCA }}
@@ -198,6 +200,9 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+      - name: tempdir
+        emptyDir: {}
+        sizeLimit: 1Gi      
       - name: configdir
         emptyDir: {}
       - name: configtemplate

--- a/helm/flowforge/templates/deployment.yaml
+++ b/helm/flowforge/templates/deployment.yaml
@@ -201,8 +201,8 @@ spec:
       {{- end }}
       volumes:
       - name: tempdir
-        emptyDir: {}
-        sizeLimit: 1Gi      
+        emptyDir: 
+          sizeLimit: 1Gi      
       - name: configdir
         emptyDir: {}
       - name: configtemplate


### PR DESCRIPTION
## Description

This pull request enables writable `/tmp` directory in forge pod by utilising `emptyDir` volume approach.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/pull/5367

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

