### PR TITLE
feat: Remove hardcoded private npm registry credentials

### DIFF
--- a/helm/flowforge/README.md
+++ b/helm/flowforge/README.md
@@ -253,7 +253,7 @@ Everything under `forge.rate_limits` is used as input to Fastify Rate Limit plug
  - `forge.npmRegistry.enabled` Enable/disable support for Per Team Private NPM Registry (default `false`)
  - `forge.npmRegistry.url` URL for the registry (default not set, required if enabled)
  - `forge.npmRegistry.admin.username` Username for a admin user on the registry (default not set, required if enabled)
- - `forge.npmRegistry.admin.password` Password for a admin user on the registry (default not set, required if enabled)
+ - `forge.npmRegistry.admin.password` Password for a admin user on the registry (default not set)
 
  ### Ingress
  - `ingress.annotations` ingress annotations (default is `{}`). This value is also applied to Editor instances created by FlowForge.

--- a/helm/flowforge/templates/_helpers.tpl
+++ b/helm/flowforge/templates/_helpers.tpl
@@ -209,4 +209,16 @@ Configure emqx bootstrap api secret
 {{- else }}
 {{- randAlphaNum 32 -}}
 {{- end }}
+{{- end }}
+
+{{/*
+Generate NPM registry admin password if not provided
+*/}}
+{{- define "forge.npmRegistryAdminPassword" -}}
+{{- if and (hasKey .Values.forge "npmRegistry") (hasKey .Values.forge.npmRegistry "admin") (hasKey .Values.forge.npmRegistry.admin "password") }}
+{{- .Values.forge.npmRegistry.admin.password }}
+{{- else }}
+{{- $seed := printf "%s-%s-%s" .Release.Name .Release.Namespace "npm-registry-secret" }}
+{{- sha256sum $seed | trunc 25 }}
+{{- end }}
 {{- end -}}

--- a/helm/flowforge/templates/configmap.yaml
+++ b/helm/flowforge/templates/configmap.yaml
@@ -284,6 +284,6 @@ data:
       url: {{ .Values.forge.npmRegistry.url }}
       admin:
         username: {{ .Values.forge.npmRegistry.admin.username }}
-        password: {{ .Values.forge.npmRegistry.admin.password }}
+        password: {{ include "forge.npmRegistryAdminPassword" . }}
     {{- end }}
     {{- end }}

--- a/helm/flowforge/templates/npm-registry.yaml
+++ b/helm/flowforge/templates/npm-registry.yaml
@@ -16,7 +16,7 @@ stringData:
       ff-auth:
         baseURL: http://forge.{{ .Release.Namespace }}
         adminUser: {{ .Values.forge.npmRegistry.admin.username }}
-        adminSecret: {{ .Values.forge.npmRegistry.admin.password }}
+        adminSecret: {{ include "forge.npmRegistryAdminPassword" . }}
     packages:
       '@*/*':
         access: $authenticated

--- a/helm/flowforge/values.schema.json
+++ b/helm/flowforge/values.schema.json
@@ -936,7 +936,7 @@
                                     "type": "string"
                                 }
                             },
-                            "required": ["username", "password"]
+                            "required": ["username"]
                         }
                     },
                     "if": {


### PR DESCRIPTION
## Description

This pull requests generates private npm registry pasword if none is provided.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/551

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

