### PR TITLE
fix:Disable skipping existing package release

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           charts_dir: helm
           config: .github/configs/cr.yaml
-          skip_existing: true
+          skip_existing: false
 
       - name: Update main changelog
         if: steps.semantic-release.outputs.new_release_published == 'true'


### PR DESCRIPTION
## Description

This pull requests sets `skip_existing` parameter to `false` for `helm/chart-releaaser-action` to ensure, that both helm charts are uploaded.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/486

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

