### PR TITLE
feat: Add possibility to customise team broker image 

### DIFF
--- a/helm/flowfuse/README.md
+++ b/helm/flowfuse/README.md
@@ -121,6 +121,7 @@ To use STMP to send email
 
 ### Team Broker
 
+  - `broker.image` defines the container image for the Team Broker (default `emqx:5`)
   - `broker.storageClassName` the StorageClass to use for the teamBroker persistent Storage
   - `broker.listenersServiceTemplate` Service spec for the MQTT listeners
   - `broker.dashboardServiceTemplate` Service spec for the teamBroker admin console

--- a/helm/flowfuse/templates/emqx.yaml
+++ b/helm/flowfuse/templates/emqx.yaml
@@ -7,7 +7,7 @@ kind: EMQX
 metadata:
     name: emqx
 spec:
-    image: emqx:5
+    image: {{ .Values.broker.image }}
     imagePullPolicy: IfNotPresent
     config:
         data: |

--- a/helm/flowfuse/values.schema.json
+++ b/helm/flowfuse/values.schema.json
@@ -1044,6 +1044,9 @@
         "broker": {
             "type": "object",
             "properties": {
+                "image": {
+                    "type": "string"
+                },
                 "storageClassName": {
                     "type": "string"
                 },

--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -171,6 +171,7 @@ editors:
     name: editors
 
 broker:
+  image: emqx:5
   storageClassName: ''
   listenersServiceTemplate: {}
   dashboardServiceTemplate: {}


### PR DESCRIPTION
## Description

This pull request adds the possibility to customise Team Broker images used by the broker deployment.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

