### PR TITLE
feat: Update base container images to `node:20-alpine`

### DIFF
--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN

--- a/flowforge-container/Dockerfile
+++ b/flowforge-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
## Description

This pull request updates base container images used to build forge and file-server containers to `node:20-alpine`

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/5403

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

