### PR TITLE
fix: Switch to  `bitnamilegacy/postgresql` registry for local postgresql 

### DIFF
--- a/helm/flowfuse/values.yaml
+++ b/helm/flowfuse/values.yaml
@@ -155,6 +155,7 @@ forge:
 
 postgresql:
   image:
+    repository: bitnamilegacy/postgresql
     tag: "14.10.0-debian-11-r30"
   auth:
     postgresPassword: Moomiet0


### PR DESCRIPTION
## Description

This pull request changes default registry for `postgresql` image to `bitnamilegacy/postgresql` due to the changes described in linked issue.

## Related Issue(s)

closes https://github.com/FlowFuse/helm/issues/638

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

