### PR TITLE
feat: Allow forge.registry to be used for init containers

### DIFF
--- a/helm/flowfuse/templates/deployment.yaml
+++ b/helm/flowfuse/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       initContainers:
       - name: config
-        image: "ruby:2.7-slim"
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}ruby:2.7-slim
         imagePullPolicy: Always
         command: ['sh', '-c', 'erb /tmpl/flowforge.yml > /config/flowforge.yml']
         volumeMounts:
@@ -82,7 +82,7 @@ spec:
         {{- end }}
       {{- if .Values.forge.localPostgresql }}
       - name: wait-for-local-db
-        image: "postgres:14"
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}postgres:14
         imagePullPolicy: Always
         command: ['sh', '-c', 'until pg_isready -h {{ include "forge.databaseHost" . }} -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}; do sleep 2; done;']
         securityContext:

--- a/helm/flowfuse/templates/emqx-exporter.yaml
+++ b/helm/flowfuse/templates/emqx-exporter.yaml
@@ -37,7 +37,7 @@ spec:
         runAsUser: 1000
       initContainers:
       - name: config
-        image: "ruby:2.7-slim"
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}ruby:2.7-slim
         imagePullPolicy: Always
         command: ['sh', '-c', 'erb /tmpl/config.yaml > /config/config.yaml' ]
         volumeMounts:
@@ -59,7 +59,7 @@ spec:
               - ALL
       containers:
         - name: exporter
-          image: emqx/emqx-exporter:0.2
+          image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}emqx/emqx-exporter:0.2
           imagePullPolicy: IfNotPresent
           args:
             - --config.file

--- a/helm/flowfuse/templates/file-storage.yml
+++ b/helm/flowfuse/templates/file-storage.yml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       initContainers:
       - name: config
-        image: "ruby:2.7-slim"
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}ruby:2.7-slim
         imagePullPolicy: Always
         command: ['sh', '-c', 'erb /tmpl/flowforge-storage.yml > /config/flowforge-storage.yml' ]
         volumeMounts:
@@ -84,7 +84,7 @@ spec:
               - ALL
       {{ if .Values.forge.localPostgresql -}}
       - name: wait-for-local-db
-        image: "postgres:14"
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}postgres:14
         imagePullPolicy: Always
         command: ['sh', '-c', 'until pg_isready -h {{ include "forge.databaseHost" . }} -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }}; do sleep 2; done;']
         securityContext:

--- a/helm/flowfuse/templates/npm-registry.yaml
+++ b/helm/flowfuse/templates/npm-registry.yaml
@@ -55,7 +55,7 @@ spec:
         {{- if .Values.npmRegistry.image }}
         image: {{ .Values.npmRegistry.image }}
         {{ else }}
-        image: flowfuse/npm-registry:latest
+        image: {{ .Values.forge.registry }}{{- if .Values.forge.registry -}}/{{- end -}}flowfuse/npm-registry:latest
         {{ end -}}
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
fixes Flowfuse/flowfuse#6036

## Description

<!-- Describe your changes in detail -->

Also applies to npm registry container and emqx-exporter

## Related Issue(s)

<!-- What issue does this PR relate to? -->
Flowfuse/flowfuse#6036

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

